### PR TITLE
Replace redcarpet with kramdown and use correct options for Jekyll 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+gem 'jekyll'
+gem 'jekyll-sitemap'
+gem 'kramdown'
+gem 'rouge'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,56 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    colorator (1.1.0)
+    ffi (1.9.18)
+    forwardable-extended (2.6.0)
+    jekyll (3.5.2)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 1.1)
+      kramdown (~> 1.3)
+      liquid (~> 4.0)
+      mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
+      rouge (~> 1.7)
+      safe_yaml (~> 1.0)
+    jekyll-sass-converter (1.5.0)
+      sass (~> 3.4)
+    jekyll-sitemap (0.12.0)
+      jekyll (~> 3.3)
+    jekyll-watch (1.5.0)
+      listen (~> 3.0, < 3.1)
+    kramdown (1.15.0)
+    liquid (4.0.0)
+    listen (3.0.8)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    mercenary (0.3.6)
+    pathutil (0.14.0)
+      forwardable-extended (~> 2.6)
+    public_suffix (3.0.0)
+    rb-fsevent (0.10.2)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
+    rouge (1.11.1)
+    safe_yaml (1.0.4)
+    sass (3.5.1)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll
+  jekyll-sitemap
+  kramdown
+  rouge
+
+BUNDLED WITH
+   1.12.5

--- a/_config.yml
+++ b/_config.yml
@@ -51,7 +51,7 @@ sass:
   style: :compressed
 
 # Additional gems to use
-gems:
+plugins:
   - jekyll-sitemap # Generates sitemaps for Google
 
 # Dates are not included in permalinks
@@ -66,82 +66,11 @@ future: true
 # Exclude non-site files
 exclude: ['bin','CNAME', 'README.md']
 
-# Use the redcarpet Markdown renderer
-markdown: redcarpet
-redcarpet:
-    extensions: [
-        'no_intra_emphasis',
-        'fenced_code_blocks',
-        'autolink',
-        'strikethrough',
-        'superscript',
-        'with_toc_data',
-        'tables',
-        'hardwrap'
-    ]
+highlighter: rouge
 
-##
-# Prose settings
-##
-prose:
-  rooturl: '_posts'
-  siteurl: 'https://seravo.com/docs'
-  media: 'media'
-  ignore:
-    - _config.yml
-    - /_layouts
-    - /_posts/.gitkeep
-    - /_includes
-    - assets
-    - /bin
-    - /_pages
-    - CNAME
-    - search.json
-    - bower.json
-  metadata:
-    _posts:
-      - name: "title"
-        field:
-          element: "text"
-          label: "title"
-      - name: "layout"
-        field:
-          element: "hidden"
-          value: "page"
-      - name: "date"
-        field:
-          element: "hidden"
-          value: CURRENT_DATETIME
-      - name: "category"
-        field:
-          element: "select"
-          label: "Add Category"
-          placeholder: "Pick a category"
-          alterable: true # User can add new categories
-          options:
-            -
-              name: "Get Started"
-              value: get-started
-            -
-              name: "Configuration"
-              value: configuration
-            -
-              name: "Testing"
-              value: tests
-            -
-              name: "Development"
-              value: development
-            -
-              name: "Deployment"
-              value: deployment
-            -
-              name: "Management"
-              value: management
-
-      - name: "order"
-        field:
-          element: "number"
-          label: Page order in the category
-          help: You can order pages with this
-          value: 10
-          type: "number"
+# Use the kramdown Markdown renderer
+markdown: kramdown
+kramdown:
+  input: GFM
+  auto_ids: true
+  syntax_highlighter: rouge


### PR DESCRIPTION
This replaces old Jekyll options with the current ones.

I also added Gemfile and removed the prose.io integration because that was never actually used.

Fixes #8