### PR TITLE
Navigation: Add active state and make headers more distinguishable

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -4,11 +4,17 @@
         {% assign attr = section[0] %}
         {% assign label = section[1] %}
 
-        {% for page in site.categories[attr] %}
+        {% for link in site.categories[attr] %}
             {% if forloop.first %}
                 <li class="nav-header">{{ label }}</li>
             {% endif %}
-            <li data-order="{{ page.order }}"><a href="{{ site.baseurl }}{{ page.url }}">{{ page.title }}</a></li>
+            <li data-order="{{ link.order }}">
+                {% if link.url == page.url %}
+                    <a class="is-active" href="{{ site.baseurl }}{{ link.url }}">{{ link.title }}</a>
+                {% else %}
+                    <a href="{{ site.baseurl }}{{ link.url }}">{{ link.title }}</a>
+                {% endif %}
+            </li>
         {% endfor %}
     {% endfor %}
 <!-- List additional links. It is recommended to add a divider

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -204,9 +204,15 @@ input:focus:-ms-input-placeholder { color:transparent; } /* IE 10+ */
         padding-right: 10px;
     }
 
+    li a.is-active {
+        background-color: #eee;
+    }
+
     .nav-header {
         padding-left: 0;
         padding-right: 0;
+        margin-top: 16px;
+        font-weight: 700;
     }
 }
 


### PR DESCRIPTION
This PR adds active state to the navigation (same as hover and focus) and makes nav sections a bit more distinguishable by separating sections and making headers bolder.

Before:
![seravo-docs-before](https://user-images.githubusercontent.com/1389199/47083775-56150180-d21a-11e8-87d5-5d5e43ad257f.png)

After:
![seravo-docs-after](https://user-images.githubusercontent.com/1389199/47083777-56ad9800-d21a-11e8-8a04-63767e138b54.png)
