### PR TITLE
Instruct to install Vagrant 2.0.4 instead of newest version

### DIFF
--- a/_posts/2015-10-12-how-to-install.md
+++ b/_posts/2015-10-12-how-to-install.md
@@ -14,8 +14,10 @@ order: 2
 
 To use Virtualbox make sure you have ```vt-x``` enabled in your BIOS.
 
+[Install Vagrant 2.0.4](https://releases.hashicorp.com/vagrant/2.0.4/). Don't install the latest version, as there is compatibility issues with the current version of Seravo WordPress Vagrant box.
+
 ```bash
-sudo apt-get install -y vagrant virtualbox virtualbox-dkms
+sudo apt-get install -y virtualbox virtualbox-dkms
 git clone https://github.com/Seravo/wordpress ~/wordpress-dev
 cd ~/wordpress-dev
 vagrant plugin install vagrant-hostsupdater vagrant-triggers vagrant-bindfs
@@ -56,10 +58,12 @@ commands, instead of the modern `ip` command. For networking to work properly, y
 Add RPMFusion repositories. See  [RpmFusion](http://rpmfusion.org/). Repository is
 needed for Virtualbox.
 
+[Install Vagrant 2.0.4](https://releases.hashicorp.com/vagrant/2.0.4/). Don't install the latest version, as there is compatibility issues with the current version of Seravo WordPress Vagrant box.
+
 Clone the WordPress Git repo and run following commands:
 
 ```bash
-sudo yum install vagrant virtualbox
+sudo yum install virtualbox
 sudo yum install ruby-devel # Needed to build native ruby extensions
 sudo gem update bundler
 sudo gem install hittimes -v '1.2.2'


### PR DESCRIPTION
Current instructions lead to installing the newest version of Vagrant, while version 2.0.4 would be preferable.