### PR TITLE
Warning for 3rd party WP plugins & shadow cookies

### DIFF
--- a/_posts/2016-05-11-shadows.md
+++ b/_posts/2016-05-11-shadows.md
@@ -109,3 +109,9 @@ With `curl` you can fetch a file from the shadow in the following way:
 ```
 curl -iLs https://example.com/test/?seravo_shadow=456def"
 ```
+
+### Caveat: 3rd party WP plugins may not set the shadow cookie
+
+Third party WordPress plugins may depend on the WordPress REST API. If they call this API without including the shadow cookie, the production WP instance will be called. This is not expected behavior and can lead to plugin errors or data loss on production servers. An example of such a plugin is [Mailchimp for Woocommerce](https://wordpress.org/plugins/mailchimp-for-woocommerce/).
+
+This can only be resolved by modifying the plugin code to add the shadow cookie to the headers of the REST request.


### PR DESCRIPTION
This adds a warning for 3rd party plugins that don't include the shadow cookies in WP REST requests.  I encountered this issue with the plugin Mailchimp for Woocommerce, it was calling the production instance because the shadow cookie was not set. The production instance did not have this plugin installed thus the REST request errored out. 

For me this was not a serious problem, but I can image scenarios where a plugin was installed in production and could be modified by actions from the staging instance of that plugin.
 
I resolved my issue by adding [a line](https://github.com/mailchimp/mc-woocommerce/blob/master/bootstrap.php#L951) with this code:
```
$headers['cookie'] = 'wpp_shadow=<MY_SHADOW_ID>; seravo_shadow=<MY_SHADOW_ID>;';
```

I think the general case should be documented here since it is a Seravo-specific shadow cookie issue that might occur in other plugins too.