### PR TITLE
Change the banner to promote the 2020 webinars

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,9 +16,10 @@
                 <ul id="results-container"></ul>
             </div>
 
+            <!-- Shown for visitors with a browser in fi or fi-FI, see assets/main.js for logic -->
             <div class="row" id="dev-training-banner" style="display: none">
               <span class="close">X</span>
-              <p>Tiesitkö että Seravo tarjoaa myös <a href="https://wp-palvelu.fi/wordpress-koulutukset/kehittajalle/">WordPress-sivustojen kehittäjille koulutuksia</a>?</p>
+              <p>WordPress-kehittäjä, älä missaa <a href="https://wp-palvelu.fi/blogi/wordpress-webinaareja-kehittajille/"> kevään 2020 webinaarisarjaa</a>!</p>
             </div>
 
             <div class="row">


### PR DESCRIPTION
This PR will change the banner displayed to Finnish visitors to promote the 2020 webinars instead of dev trainings.