### PR TITLE
Add man pages

### DIFF
--- a/_posts/2015-10-13-available-commands.md
+++ b/_posts/2015-10-13-available-commands.md
@@ -18,109 +18,109 @@ Vagrant box contains plenty of helpers for developing your site and migrating da
 ### Admin helpers
 
 #### wp-backup
-`wp-backup` - Dump the WordPress database and backup the `/data` directory into `/data/backups/data` using `rdiff-backup`.
+[`wp-backup`](/docs/man/wp-backup) - Dump the WordPress database and backup the `/data` directory into `/data/backups/data` using `rdiff-backup`.
 
 #### wp-backup-list-changes
-`wp-backup-list-changes` - List all files known by `rdiff-backup` sorted by date when backed up. Use this to find out what files really changed in the system, as the file attribute mtime is not a reliable source of information. Use `rdiff-backup --exclude /data/backups --compare-at-time now /data /data/backs/data/` to find out how the current data differs from latest backup.
+[`wp-backup-list-changes`](/docs/man/wp-backup-list-changes) - List all files known by `rdiff-backup` sorted by date when backed up. Use this to find out what files really changed in the system, as the file attribute mtime is not a reliable source of information. Use `rdiff-backup --exclude /data/backups --compare-at-time now /data /data/backs/data/` to find out how the current data differs from latest backup.
 
 #### wp-backup-status
-`wp-backup-status` - List all backup increments known by `rdiff-backup` by date. Use this to find out what backups exists. This is an alias of `rdiff-backup --list-increment-sizes /data/backups/data`.
+[`wp-backup-status`](/docs/man/wp-backup-status) - List all backup increments known by `rdiff-backup` by date. Use this to find out what backups exists. This is an alias of `rdiff-backup --list-increment-sizes /data/backups/data`.
 
 #### wp-fix-checksums
-`wp-fix-checksums` - Automatically fix typical situations where `wp core verify-checksums` has detected an error (core files changed/tampered). Does not attempt to fix any warnings returned.
+[`wp-fix-checksums`](/docs/man/wp-fix-checksums) - Automatically fix typical situations where `wp core verify-checksums` has detected an error (core files changed/tampered). Does not attempt to fix any warnings returned.
 
 #### wp-flush-cache
-`wp-flush-cache` - Wrapper for `wp-purge-cache` with flush cache terminology in line with what wp-cli uses. See `wp-purge-cache`.
+[`wp-flush-cache`](/docs/man/wp-purge-cache) - Wrapper for `wp-purge-cache` with flush cache terminology in line with what wp-cli uses. See `wp-purge-cache`.
 
 #### wp-last-ssh-logins
-`wp-last-ssh-logins` - List last logins according to system status history and failed logins based on wtmp and btmp logs.
+[`wp-last-ssh-logins`](/docs/man/wp-last-ssh-logins) - List last logins according to system status history and failed logins based on wtmp and btmp logs.
 
 #### wp-list-files-mtime
-`wp-list-files-mtime` - List all recently changed filed based on modification time (mtime attribute). Files modified during the last 30 days are listed. This is less reliable than `wp-backup-list-changes` as files can have their mtime attribute set to anything.
+[`wp-list-files-mtime`](/docs/man/wp-list-files-mtime) - List all recently changed filed based on modification time (mtime attribute). Files modified during the last 30 days are listed. This is less reliable than `wp-backup-list-changes` as files can have their mtime attribute set to anything.
 
 #### wp-speed-test
-`wp-speed-test` - Measure the load time of WordPress (PHP) page loads. Tests site front page by default, but other URLs can be given as an argument. Supports parameter `--cache` which will test how fast the sites load from front proxy (not PHP) if the tested URL supports HTTP level caching.
+[`wp-speed-test`](/docs/man/wp-speed-test) - Measure the load time of WordPress (PHP) page loads. Tests site front page by default, but other URLs can be given as an argument. Supports parameter `--cache` which will test how fast the sites load from front proxy (not PHP) if the tested URL supports HTTP level caching.
 
 #### wp-load-test
-`wp-load-test` - A simple command line tool to measure how many consecutive PHP requests the site can handle in a minute. Accepts same parameters as `wp-speed-test`.
+[`wp-load-test`](/docs/man/wp-load-test) - A simple command line tool to measure how many consecutive PHP requests the site can handle in a minute. Accepts same parameters as `wp-speed-test`.
 
 #### wp-mail-test
-`wp-mail-test` - A simple command line tool to test that that PHP `mail()` works as expected. Combine with mail-tester.com for most comprehensive results.
+[`wp-mail-test`](/docs/man/wp-mail-test) - A simple command line tool to test that that PHP `mail()` works as expected. Combine with mail-tester.com for most comprehensive results.
 
 #### wp-optimize-images
-`wp-optimize-images` - Optimize images on site. Can be given a path as a parameter but scans `/data/wordpress/htdocs/wp-content/uploads/\` but default. Runs only if the `seravo-enable-optimize-images` value in the database is set to true. Reduces the resolution of all JPEG files according to maximum width and height saved in the database table `wp_options`as`seravo-image-max-resolution-width`and`seravo-image-max-resolution-width`. Maximum image quality for JPEG is set to 90. Image quality for PNG files is set to 7. Prints the output to terminal and `/data/log/wp-optimize-images.log`.
+[`wp-optimize-images`](/docs/man/wp-optimize-images) - Optimize images on site. Can be given a path as a parameter but scans `/data/wordpress/htdocs/wp-content/uploads/\` but default. Runs only if the `seravo-enable-optimize-images` value in the database is set to true. Reduces the resolution of all JPEG files according to maximum width and height saved in the database table `wp_options`as`seravo-image-max-resolution-width`and`seravo-image-max-resolution-width`. Maximum image quality for JPEG is set to 90. Image quality for PNG files is set to 7. Prints the output to terminal and `/data/log/wp-optimize-images.log`.
 
 #### wp-purge-cache
-`wp-purge-cache` - Purge all server caches: Nginx proxy cache, WordPress object cache, WordPress rewrite cache and PageSpeed cache.
+[`wp-purge-cache`](/docs/man/wp-purge-cache) - Purge all server caches: Nginx proxy cache, WordPress object cache, WordPress rewrite cache and PageSpeed cache.
 
 #### wp-reset-all-passwords
-`wp-reset-all-passwords` - Reset passwords for all registered WordPress users. Automatically also resets sessions.
+[`wp-reset-all-passwords`](/docs/man/wp-reset-all-passwords) - Reset passwords for all registered WordPress users. Automatically also resets sessions.
 
 #### wp-reset-all-sessions
-`wp-reset-all-sessions` - Reset sessions for all users, after which each user needs to login again.
+[`wp-reset-all-sessions`](/docs/man/wp-reset-all-sessions) - Reset sessions for all users, after which each user needs to login again.
 
 #### wp-reset-ssh-password
-`wp-reset-ssh-password` - Reset the SSH passwords. This is the only way to change the SSH password for a site at Seravo.
+[`wp-reset-ssh-password`](/docs/man/wp-reset-ssh-password) - Reset the SSH passwords. This is the only way to change the SSH password for a site at Seravo.
 
 #### wp-seravo-plugin-update
-`wp-seravo-plugin-update` - Update the must-use Seravo Plugin to the latest version. It also cleans up all legacy remnants of the `wp-palvelu-plugin`. Use `--dev` parameter to pull latest git master instead of the latest stable release.
+[`wp-seravo-plugin-update`](/docs/man/wp-seravo-plugin-update) - Update the must-use Seravo Plugin to the latest version. It also cleans up all legacy remnants of the `wp-palvelu-plugin`. Use `--dev` parameter to pull latest git master instead of the latest stable release.
 
 
 ### Developer helpers
 
 #### wp-list-env
-`wp-list-env` - Print a list of defined environment variables. Both the Vagrant image and the production server contain ENVs which define ports and credentials for WordPress. With this command you can debug the settings that you have.
+[`wp-list-env`](/docs/man/wp-list-env) - Print a list of defined environment variables. Both the Vagrant image and the production server contain ENVs which define ports and credentials for WordPress. With this command you can debug the settings that you have.
 
 #### wp-makepot
-`wp-makepot` - is a wrapper for `php /opt/wordpress/i18n/tools/makepot.php`. For more information on internationalization read the corresponding page on [WordPress Codex](https://codex.wordpress.org/I18n_for_WordPress_Developers).
+[`wp-makepot`](/docs/man/wp-makepot) - is a wrapper for `php /opt/wordpress/i18n/tools/makepot.php`. For more information on internationalization read the corresponding page on [WordPress Codex](https://codex.wordpress.org/I18n_for_WordPress_Developers).
 
 #### wp-pomo-compile
-`wp-pomo-compile` - Find .po files, process each with `msgfmt` and generate binary .mo files. Can be given a target path as an argument, otherwise the process is done on `/data/wordpress/htdocs/wp-content/` and all subdirectories.
+[`wp-pomo-compile`](/docs/man/wp-pomo-compile) - Find .po files, process each with `msgfmt` and generate binary .mo files. Can be given a target path as an argument, otherwise the process is done on `/data/wordpress/htdocs/wp-content/` and all subdirectories.
 
 #### wp-restart-nginx
-`wp-restart-nginx` - Restart Nginx. Does not require root permissions. Applies all configuration at `/data/wordpress/nginx/*.conf`.
+[`wp-restart-nginx`](/docs/man/wp-restart-nginx) - Restart Nginx. Does not require root permissions. Applies all configuration at `/data/wordpress/nginx/*.conf`.
 
 #### wp-restart-php
-`wp-restart-php` - Restart all PHP processes.
+[`wp-restart-php`](/docs/man/wp-restart-php) - Restart all PHP processes.
 
 #### wp-shadow-pull
-`wp-shadow-pull` - Replace files and database contents in your production environment with your chosen shadow environment. Use with caution, as it may break your site. Makes a backup for you automatically.
+[`wp-shadow-pull`](/docs/man/wp-shadow-pull) - Replace files and database contents in your production environment with your chosen shadow environment. Use with caution, as it may break your site. Makes a backup for you automatically.
 
 #### wp-shadow-reset
-`wp-shadow-reset` - Replace files and database in a shadow environment with data from the production environment. Will delete and replace all files in the `/data/wordpress/` directory of a shadow with a clone from production. Use with caution, as data from your shadow can not be recovered after this process.
+[`wp-shadow-reset`](/docs/man/wp-shadow-reset) - Replace files and database in a shadow environment with data from the production environment. Will delete and replace all files in the `/data/wordpress/` directory of a shadow with a clone from production. Use with caution, as data from your shadow can not be recovered after this process.
 
 #### wp-test
-`wp-test` - Run the [Codeception integration tests]({{ site.baseurl }}{% post_url 2018-09-21-ng-integration-tests %}).
+[`wp-test`](/docs/man/wp-test) - Run the [Codeception integration tests]({{ site.baseurl }}{% post_url 2018-09-21-ng-integration-tests %}).
 
 #### wp-test-whitelist
-`wp-test-whitelist` - Add an error or warning message to the [Codeception whitelist]({{ site.baseurl }}{% post_url 2018-09-21-ng-integration-tests %}).
+[`wp-test-whitelist`](/docs/man/wp-test-whitelist) - Add an error or warning message to the [Codeception whitelist]({{ site.baseurl }}{% post_url 2018-09-21-ng-integration-tests %}).
 
 #### wp-watch-logs
-`wp-watch-logs` - Print all new linest written to any of the logs under `/data/log/`. Press Ctrl+C to exit.
+[`wp-watch-logs`](/docs/man/wp-watch-logs) - Print all new linest written to any of the logs under `/data/log/`. Press Ctrl+C to exit.
 
 
 ### Database helpers
 
 #### wp-db-optimize
-`wp-db-optimize` - Run the CHECK and OPTIMIZE tasks for the WordPress database.
+[`wp-db-optimize`](/docs/man/wp-db-optimize) - Run the CHECK and OPTIMIZE tasks for the WordPress database.
 
 #### wp-db-cleanup
-`wp-db-cleanup` - Remove older than current year post revisions from database. Use with caution, this is destructive operation. Operation is cancelable within 10 seconds by typing Ctrl+C.
+[`wp-db-cleanup`](/docs/man/wp-db-cleanup) - Remove older than current year post revisions from database. Use with caution, this is destructive operation. Operation is cancelable within 10 seconds by typing Ctrl+C.
 
 #### wp-db-info
-`wp-db-info` - Display database table size in bytes and wp_option record lenghts.
+[`wp-db-info`](/docs/man/wp-db-info) - Display database table size in bytes and wp_option record lenghts.
 
 #### wp-db-dump
-`wp-db-dump` - Dump current database into /data/db/. This file will normally be the daily backup database dump.
+[`wp-db-dump`](/docs/man/wp-db-dump) - Dump current database into /data/db/. This file will normally be the daily backup database dump.
 
 #### wp-db-load
-`wp-db-load` - Replace current database with existing dump from /data/db/
+[`wp-db-load`](/docs/man/wp-db-load) - Replace current database with existing dump from /data/db/
 
 #### wp-db-update
-`wp-db-update` - Apply all pending wordpress database schema updates, if any
+[`wp-db-update`](/docs/man/wp-db-update) - Apply all pending wordpress database schema updates, if any
 
 #### wp-db-admin
-`wp-db-admin` - Access the MariaDB Proxy admin console
+[`wp-db-admin`](/docs/man/wp-db-admin) - Access the MariaDB Proxy admin console
 
 
 ### Vagrant commands
@@ -128,16 +128,16 @@ Vagrant box contains plenty of helpers for developing your site and migrating da
 > **Note:** These are only available inside the Vagrant box.
 
 #### wp-xdebug-on/off
-`wp-xdebug-on` and `wp-xdebug-off` - Activate and deactivates the [Xdebug profiler]({{ site.baseurl }}{% post_url 2015-10-11-xdebug %}). Run `wp-xdebug-off` if the Vagrant box seems sluggish to speed it up, as Xdebug can sometimes be quite heavy on the virtual machine load.
+[`wp-xdebug-on`](/docs/man/wp-xdebug-on) and [`wp-xdebug-off`](/docs/man/wp-xdebug-off) - Activate and deactivates the [Xdebug profiler]({{ site.baseurl }}{% post_url 2015-10-11-xdebug %}). Run `wp-xdebug-off` if the Vagrant box seems sluggish to speed it up, as Xdebug can sometimes be quite heavy on the virtual machine load.
 
 #### wp-ssh-production
-`wp-ssh-production` - Log into production with SSH. Requires the config.yml to have the `production` section defined.
+[`wp-ssh-production`](/docs/man/wp-ssh-production) - Log into production with SSH. Requires the config.yml to have the `production` section defined.
 
 #### wp-pull-production-db
-`wp-pull-production-db` - Copy the production database into local Vagrant box. Also replaces all production *siteurls* in the database with the local development *siteurl* based on the contents of `config.yml`.
+[`wp-pull-production-db`](/docs/man/wp-pull-production-db) - Copy the production database into local Vagrant box. Also replaces all production *siteurls* in the database with the local development *siteurl* based on the contents of `config.yml`.
 
 #### wp-pull-production-plugins
-`wp-pull-production-plugins` - Pull the plugins used in production. Uses `rsync` to make sure local `wp-content/plugins` is equal to the one in prodction.
+[`wp-pull-production-plugins`](/docs/man/wp-pull-production-plugins) - Pull the plugins used in production. Uses `rsync` to make sure local `wp-content/plugins` is equal to the one in prodction.
 
 
 ### Vagrant internal commands
@@ -145,21 +145,21 @@ Vagrant box contains plenty of helpers for developing your site and migrating da
 > **Note**: These commands are used by the `Vagrantfile`. These are not intended for manual invocation by any WordPress site developer.
 
 #### wp-activate-git-hooks
-`wp-activate-git-hooks` - Adds files to local `.git/hooks` for test automation on every local `git commit`. Read more about [git hooks]({{ site.baseurl }}{% post_url 2015-10-12-using-git-hooks %})
+[`wp-activate-git-hooks`](/docs/man/wp-activate-git-hooks) - Adds files to local `.git/hooks` for test automation on every local `git commit`. Read more about [git hooks]({{ site.baseurl }}{% post_url 2015-10-12-using-git-hooks %})
 
 #### wp-generate-ssl
-`wp-generate-ssl` - Generate SSL self-signed certificates for domains defined in `config.yml`.
+[`wp-generate-ssl`](/docs/man/wp-generate-ssl) - Generate SSL self-signed certificates for domains defined in `config.yml`.
 
 #### wp-use-asset-proxy
-`wp-use-asset-proxy` - Set an asset proxy for the development environment based on `config.yml`.
+[`wp-use-asset-proxy`](/docs/man/wp-use-asset-proxy) - Set an asset proxy for the development environment based on `config.yml`.
 
 #### wp-vagrant-activation
-`wp-vagrant-activation` - Restart Nginx and the Avahi daemon, and generates domains mappings in `/etc/hosts` and configure production details to `.ssh/config`.
+[`wp-vagrant-activation`](/docs/man/wp-vagrant-activation) - Restart Nginx and the Avahi daemon, and generates domains mappings in `/etc/hosts` and configure production details to `.ssh/config`.
 
 #### wp-vagrant-dump-db
-`wp-vagrant-dump-db` - This is run everytime you `halt` or `destroy` the Vagrant box so that the database can be re-imported on the next `vagrant up` run. Database dump is stored in the local `.vagrant` directory.
+[`wp-vagrant-dump-db`](/docs/man/wp-vagrant-dump-db) - This is run everytime you `halt` or `destroy` the Vagrant box so that the database can be re-imported on the next `vagrant up` run. Database dump is stored in the local `.vagrant` directory.
 
 #### wp-vagrant-import-db
-`wp-vagrant-import-db` - This is run everytime you `up` the Vagrant box. It tries to import the dump file generated by `wp-vagrant-dump-db` so you can continue development where you left off.
+[`wp-vagrant-import-db`](/docs/man/wp-vagrant-import-db) - This is run everytime you `up` the Vagrant box. It tries to import the dump file generated by `wp-vagrant-dump-db` so you can continue development where you left off.
 
 </div>

--- a/man/wp-activate-asset-proxy.md
+++ b/man/wp-activate-asset-proxy.md
@@ -1,0 +1,27 @@
+---
+title: "wp-activate-asset-proxy"
+---
+
+
+# NAME
+
+wp-activate-asset-proxy - manual page for wp-activate-asset-proxy git
+version fba2a66
+
+# DESCRIPTION
+
+usage: wp-activate-asset-proxy \[-h\] \[--version\]
+
+Activate asset proxy to avoid need to download WordPress uploads
+directory. Update Nginx settings to that requests to
+/wp-content/uploads/\* are transparently proxied from the production
+site, eliminating the need to download the uploads directory from the
+production site to the local development site (or to shadow sites).
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit

--- a/man/wp-activate-git-hooks.md
+++ b/man/wp-activate-git-hooks.md
@@ -1,0 +1,23 @@
+---
+title: "wp-activate-git-hooks"
+---
+
+
+# NAME
+
+wp-activate-git-hooks - manual page for wp-activate-git-hooks git
+version fba2a66
+
+# DESCRIPTION
+
+usage: wp-activate-git-hooks \[options\]
+
+Active githooks in scripts folder.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit

--- a/man/wp-backup-list-changes-ng.md
+++ b/man/wp-backup-list-changes-ng.md
@@ -1,0 +1,35 @@
+---
+title: "wp-backup-list-changes-ng"
+---
+
+
+# NAME
+
+wp-backup-list-changes-ng - manual page for wp-backup-list-changes-ng
+git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-backup-list-changes-ng \[-h\] \[--version\]
+
+> \[--increments-dir INCREMENTS\_DIR\]
+
+Lists all files known by rdiff-backup sorted by timestamp. Use this to
+find out what files really changed in the system, as the file attribute
+mtime is not a reliable source of information. "." before filename
+indicates the file was modified. "+" before filename indicates the file
+was added. "-" before filename indicates the file was removed. Use
+'rdiff-backup **--exclude** */data/backups* **--compare-at-time** now
+*/data* /data/backs/data/' to find out how the current data differs from
+latest backup.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit
+
+  - **--increments-dir** INCREMENTS\_DIR  
+    rdiff-backup directory containing increments

--- a/man/wp-backup-list-changes-since.md
+++ b/man/wp-backup-list-changes-since.md
@@ -1,0 +1,31 @@
+---
+title: "wp-backup-list-changes-since"
+---
+
+
+# NAME
+
+wp-backup-list-changes-since - manual page for
+wp-backup-list-changes-since git version fba2a66
+
+# SYNOPSIS
+
+**wp-backup-list-changes-since** \[*-h*\] \[*--version*\] *\<time
+string\>*
+
+# DESCRIPTION
+
+List files changed since given date, e.g. '2020-08-13'.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit
+
+# SEE ALSO
+
+*wp-backup-list-changes*(1), *wp-list-files-mtime*(1), *wp-db-dump*(1),
+*rdiff-backup*(1)

--- a/man/wp-backup-list-changes.md
+++ b/man/wp-backup-list-changes.md
@@ -1,0 +1,42 @@
+---
+title: "wp-backup-list-changes"
+---
+
+
+# NAME
+
+wp-backup-list-changes - manual page for wp-backup-list-changes git
+version fba2a66
+
+# SYNOPSIS
+
+**wp-backup-list-changes** \[*-h*\] \[*--version*\]
+\[*--skip-database*\]
+
+# DESCRIPTION
+
+Lists all files known by rdiff-backup sorted by timestamp.
+
+Use this to find out what files really changed in the system, as the
+file attribute mtime is not a reliable source of information.
+
+For more detailed information, use 'rdiff-backup' commands directly.
+
+For example, to find out how the current data differs from latest backup
+run:
+
+> rdiff-backup **--exclude** */data/backups* **--compare-at-time** now
+> */data* /data/backs/data/
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit
+
+# SEE ALSO
+
+*wp-backup-list-changes-since*(1), *wp-list-files-mtime*(1),
+*wp-db-dump*(1), *rdiff-backup*(1)

--- a/man/wp-backup-status.md
+++ b/man/wp-backup-status.md
@@ -1,0 +1,31 @@
+---
+title: "wp-backup-status"
+---
+
+
+# NAME
+
+wp-backup-status - manual page for wp-backup-status git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-backup-status \[options\]
+
+List all backup increments currently available.
+
+wp-backup-status is a shell program which lists all increments echo
+known by rdiff-backup sorted by timestamp. Use this to find out what
+kind of backups you are able to restore. This is an alias of
+"rdiff-backup **--list-increment-sizes** /data/backups/data".
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit
+
+# SEE ALSO
+
+*wp-backup-status*(1), *wp-backup*(1), *rdiff-backup*(1)

--- a/man/wp-backup.md
+++ b/man/wp-backup.md
@@ -1,0 +1,37 @@
+---
+title: "wp-backup"
+---
+
+
+# NAME
+
+wp-backup - manual page for wp-backup git version fba2a66
+
+# SYNOPSIS
+
+**wp-backup** \[*-h*\] \[*--version*\] \[*--skip-database*\]
+
+# DESCRIPTION
+
+Makes a backup of the entire */data* directory into
+*/data/backups/data*.
+
+The backup includes all WordPress files and a fresh database dump.
+
+Based on 'rdiff-backup' with some additional logic.
+
+## optional arguments:
+
+  - **--skip-database**  
+    skip making a fresh database dump and only backup files
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit
+
+# SEE ALSO
+
+*wp-backup-list-changes*(1), *wp-backup-list-changes-since*(1), *wp
+db*(1), *wp-db-dump*(1), *rdiff-backup*(1)

--- a/man/wp-check-haveibeenpwned.md
+++ b/man/wp-check-haveibeenpwned.md
@@ -1,0 +1,32 @@
+---
+title: "wp-check-haveibeenpwned"
+---
+
+
+# NAME
+
+wp-check-haveibeenpwned - manual page for wp-check-haveibeenpwned git
+version fba2a66
+
+# DESCRIPTION
+
+usage: wp-check-haveibeenpwned \[-h\] \[--version\] \[--json\] passhash
+
+Quick pwnedpasswords.com checker. Using
+https://haveibeenpwned.com/API/v3\#SearchingPwnedPasswordsByRange Has
+both cli and JSON interface and can be used via Seravo Plugin.
+
+## positional arguments:
+
+  - passhash  
+    SHA1 of password
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit
+
+**--json**

--- a/man/wp-check-http-cache.md
+++ b/man/wp-check-http-cache.md
@@ -1,0 +1,34 @@
+---
+title: "wp-check-http-cache"
+---
+
+
+# NAME
+
+wp-check-http-cache - manual page for wp-check-http-cache git version
+fba2a66
+
+# DESCRIPTION
+
+usage: wp-check-http-cache \[-h\] \[--version\] \[--no-https-verify\]
+\[url\]
+
+Seravo HTTP cache checker.
+
+## positional arguments:
+
+  - url  
+    The URL you want to check. If not provided, the command will attempt
+    to construct the URL using the domain from the WordPress
+    installation.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit
+
+  - **--no-https-verify**  
+    Do not verify https request certificate.

--- a/man/wp-check-https.md
+++ b/man/wp-check-https.md
@@ -1,0 +1,22 @@
+---
+title: "wp-check-https"
+---
+
+
+# NAME
+
+wp-check-https - manual page for wp-check-https git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-check-https \[-h\] \[--version\]
+
+Seravo HTTP(S) checker tool.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit

--- a/man/wp-check-loginurl.md
+++ b/man/wp-check-loginurl.md
@@ -1,0 +1,24 @@
+---
+title: "wp-check-loginurl"
+---
+
+
+# NAME
+
+wp-check-loginurl - manual page for wp-check-loginurl git version
+fba2a66
+
+# DESCRIPTION
+
+usage: wp-check-loginurl \[-h\] \[--version\] \[-p\]
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit
+
+  - **-p**, **--only-path**  
+    Return only path (default: full URL).

--- a/man/wp-check-passwords.md
+++ b/man/wp-check-passwords.md
@@ -1,0 +1,28 @@
+---
+title: "wp-check-passwords"
+---
+
+
+# NAME
+
+wp-check-passwords - manual page for wp-check-passwords git version
+fba2a66
+
+# DESCRIPTION
+
+usage: wp-check-passwords \[-h\] \[--version\] \[-f FILE\]
+
+Scan the wp\_user table for weak passwords. @TODO: Highlight users with
+admin, editor, writer privileges?
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit
+
+  - **-f** FILE, **--file** FILE  
+    Tab separated file with a user login, email and password on each
+    line

--- a/man/wp-check-php-version.md
+++ b/man/wp-check-php-version.md
@@ -1,0 +1,23 @@
+---
+title: "wp-check-php-version"
+---
+
+
+# NAME
+
+wp-check-php-version - manual page for wp-check-php-version git version
+fba2a66
+
+# DESCRIPTION
+
+usage: wp-check-php-version \[options\]
+
+Check PHP version.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit

--- a/man/wp-check-remote-failure.md
+++ b/man/wp-check-remote-failure.md
@@ -1,0 +1,30 @@
+---
+title: "wp-check-remote-failure"
+---
+
+
+# NAME
+
+wp-check-remote-failure - manual page for wp-check-remote-failure git
+version fba2a66
+
+# DESCRIPTION
+
+usage: wp-check-remote-failure \[-h\] \[--version\] \[url\]
+
+Test if WordPress continues to work without remote connections. Block
+connection to remote servers to test if WordPress continues to run as
+expected.
+
+## positional arguments:
+
+  - url  
+    URL of page to test
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit

--- a/man/wp-db-admin.md
+++ b/man/wp-db-admin.md
@@ -1,0 +1,32 @@
+---
+title: "wp-db-admin"
+---
+
+
+# NAME
+
+wp-db-admin - manual page for wp-db-admin git version fba2a66
+
+# SYNOPSIS
+
+**wp-db-admin**
+
+# DESCRIPTION
+
+Access the MariaDB Proxy admin console.
+
+In the console you can then run queries like:
+
+> SELECT \* FROM stats.stats\_mysql\_connection\_pool;
+> 
+> SELECT digest,SUBSTR(digest\_text,0,50),count\_star,sum\_time FROM
+> stats\_mysql\_query\_digest WHERE digest\_text LIKE 'SELECT%' ORDER BY
+> sum\_time DESC LIMIT 25;
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit

--- a/man/wp-db-cleanup.md
+++ b/man/wp-db-cleanup.md
@@ -1,0 +1,29 @@
+---
+title: "wp-db-cleanup"
+---
+
+
+# NAME
+
+wp-db-cleanup - manual page for wp-db-cleanup git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-db-cleanup \[-h\] \[--version\] \[--delay DELAY\]
+\[--dry-run\]
+
+Safe cleanup of cruft from database.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit
+
+  - **--delay** DELAY  
+    Safety period in seconds before cleanup
+
+  - **--dry-run**  
+    Print only how many rows would be deleted in each table

--- a/man/wp-db-cli.md
+++ b/man/wp-db-cli.md
@@ -1,0 +1,25 @@
+---
+title: "wp-db-cli"
+---
+
+
+# NAME
+
+wp-db-cli - manual page for wp-db-cli git version fba2a66
+
+# SYNOPSIS
+
+**wp-db-cli** \[*-h*\] \[*--version*\]
+
+# DESCRIPTION
+
+Quickly access the MariaDB console without having to manually enter
+credentials.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit

--- a/man/wp-db-dump.md
+++ b/man/wp-db-dump.md
@@ -1,0 +1,27 @@
+---
+title: "wp-db-dump"
+---
+
+
+# NAME
+
+wp-db-dump - manual page for wp-db-dump git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-db-dump \[options\] \[dumpfile\]
+
+Make a database dump in the standardized Seravo way.
+
+## positional arguments:
+
+  - dumpfile  
+    Path to an SQL dump file
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show version and exit

--- a/man/wp-db-info.md
+++ b/man/wp-db-info.md
@@ -1,0 +1,23 @@
+---
+title: "wp-db-info"
+---
+
+
+# NAME
+
+wp-db-info - manual page for wp-db-info git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-db-info \[options\]
+
+Show various info about the database contents useful when debugging
+slowness.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show version and exit

--- a/man/wp-db-load.md
+++ b/man/wp-db-load.md
@@ -1,0 +1,31 @@
+---
+title: "wp-db-load"
+---
+
+
+# NAME
+
+wp-db-load - manual page for wp-db-load git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-db-load \[-h\] \[--version\] \[--yes\] \[PATH\]
+
+Load a database dump in the standardized Seravo way
+
+## positional arguments:
+
+  - PATH  
+    DB dump (SQL file) to load
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit
+
+  - **--yes**  
+    Do not ask confirmation. Note: the tool will not ask for
+    confirmation if run from a non-interactive terminal.

--- a/man/wp-db-optimize.md
+++ b/man/wp-db-optimize.md
@@ -1,0 +1,25 @@
+---
+title: "wp-db-optimize"
+---
+
+
+# NAME
+
+wp-db-optimize - manual page for wp-db-optimize git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-db-optimize \[-h\] \[--version\] \[--force\]
+
+Optimize databases the correct way.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit
+
+  - **--force**  
+    Run the optimization despite system load.

--- a/man/wp-db-size.md
+++ b/man/wp-db-size.md
@@ -1,0 +1,23 @@
+---
+title: "wp-db-size"
+---
+
+
+# NAME
+
+wp-db-size - manual page for wp-db-size git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-db-size \[options\]
+
+Just a wrapper for wp-cli so one does not have to remember the command
+arguments.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show version and exit

--- a/man/wp-db-update.md
+++ b/man/wp-db-update.md
@@ -1,0 +1,22 @@
+---
+title: "wp-db-update"
+---
+
+
+# NAME
+
+wp-db-update - manual page for wp-db-update git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-db-update \[options\]
+
+Update WordPress database to match latest version of WordPress core.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show version and exit

--- a/man/wp-development-up.md
+++ b/man/wp-development-up.md
@@ -1,0 +1,23 @@
+---
+title: "wp-development-up"
+---
+
+
+# NAME
+
+wp-development-up - manual page for wp-development-up git version
+fba2a66
+
+# DESCRIPTION
+
+usage: wp-development-up \[-h\] \[--version\]
+
+Start Seravo development environment.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit

--- a/man/wp-find-code.md
+++ b/man/wp-find-code.md
@@ -1,0 +1,30 @@
+---
+title: "wp-find-code"
+---
+
+
+# NAME
+
+wp-find-code - manual page for wp-find-code git version fba2a66
+
+# SYNOPSIS
+
+**wp-find-code** *\<serach term\>*
+
+# DESCRIPTION
+
+Search for given string in the PHP files under */data/wordpress*.
+
+This is a simple wrapper for 'grep' with the purpose of saving
+developers the effor of having to manually enter 'grep' arguments.
+
+However, if there are extra arguments, they will be passed to 'grep'
+along with the default ones.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit

--- a/man/wp-fix-backups.md
+++ b/man/wp-fix-backups.md
@@ -1,0 +1,20 @@
+---
+title: "wp-fix-backups"
+---
+
+
+# NAME
+
+wp-fix-backups - manual page for wp-fix-backups git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-fix-backups \[options\]
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit

--- a/man/wp-fix-checksums.md
+++ b/man/wp-fix-checksums.md
@@ -1,0 +1,34 @@
+---
+title: "wp-fix-checksums"
+---
+
+
+# NAME
+
+wp-fix-checksums - manual page for wp-fix-checksums git version fba2a66
+
+# SYNOPSIS
+
+**wp-fix-checksums** \[*-h*\] \[*--version*\]
+
+# DESCRIPTION
+
+Checks the WordPress core installation for modified files, and if any
+are found, automatically re-installs the same WordPress version to
+ensure the core files are unmodified.
+
+Based on 'wp core verify-checksums' with some additional logic. Only 'wp
+core verify-checksum' errors are addressed. Warnings are shown but not
+fixed automatically.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit
+
+# SEE ALSO
+
+*wp core*(1)

--- a/man/wp-fix-languages.md
+++ b/man/wp-fix-languages.md
@@ -1,0 +1,23 @@
+---
+title: "wp-fix-languages"
+---
+
+
+# NAME
+
+wp-fix-languages - manual page for wp-fix-languages git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-fix-languages \[options\]
+
+Automates fixing typical situations where language packs are missing or
+not installed.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit

--- a/man/wp-fix-project.md
+++ b/man/wp-fix-project.md
@@ -1,0 +1,30 @@
+---
+title: "wp-fix-project"
+---
+
+
+# NAME
+
+wp-fix-project - manual page for wp-fix-project git version fba2a66
+
+# SYNOPSIS
+
+**wp-fix-project** \[*-h*\] \[*--version*\]
+
+# DESCRIPTION
+
+Compares the current WordPress project at */data/wordpress* to the
+upstream Seravo/WordPress project template and attempts to apply all
+upstream changes so that the project files at */data/wordpress* would be
+as up-to-date as possible.
+
+For changes that cannot be automatically applied, a diff and/or git
+patch files are provided for easier manual application.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit

--- a/man/wp-fix-wp-content-symlink.md
+++ b/man/wp-fix-wp-content-symlink.md
@@ -1,0 +1,33 @@
+---
+title: "wp-fix-wp-content-symlink"
+---
+
+
+# NAME
+
+wp-fix-wp-content-symlink - manual page for wp-fix-wp-content-symlink
+git version fba2a66
+
+# SYNOPSIS
+
+**wp-fix-wp-content-symlink** \[*-h*\] \[*--version*\] \[*--force*\]
+
+# DESCRIPTION
+
+Check that a correct wordpress/wp-content -\> ../wp-content symlink is
+found so that the WordPress installation would work correctly.
+
+If not found, tries to fix the WordPress installation and create the
+symlink correctly.
+
+## optional arguments:
+
+  - **--force**  
+    force wp-content symlink fix, useful if the fix could not otherwise
+    be applied automatically
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit

--- a/man/wp-generate-ssl.md
+++ b/man/wp-generate-ssl.md
@@ -1,0 +1,22 @@
+---
+title: "wp-generate-ssl"
+---
+
+
+# NAME
+
+wp-generate-ssl - manual page for wp-generate-ssl git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-generate-ssl \[-h\] \[--version\]
+
+Generate SSL-certificate for all domains in config.yml.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit

--- a/man/wp-git-status.md
+++ b/man/wp-git-status.md
@@ -1,0 +1,25 @@
+---
+title: "wp-git-status"
+---
+
+
+# NAME
+
+wp-git-status - manual page for wp-git-status git version fba2a66
+
+# SYNOPSIS
+
+**wp-git-status** \[*-h*\] \[*--version*\]
+
+# DESCRIPTION
+
+Show a quick summary of state of the files in */data/wordpress*, based
+on git status.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit

--- a/man/wp-last-ssh-logins.md
+++ b/man/wp-last-ssh-logins.md
@@ -1,0 +1,28 @@
+---
+title: "wp-last-ssh-logins"
+---
+
+
+# NAME
+
+wp-last-ssh-logins - manual page for wp-last-ssh-logins git version
+fba2a66
+
+# DESCRIPTION
+
+usage: wp-last-ssh-logins \[-h\] \[--version\] \[--user USER\]
+
+List latest ssh login attempts. List last logins according to system
+status history and failed logins based on wtmp and btmp.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit
+
+  - **--user** USER  
+    Analyze SSH publickey logins of given user. If not given, analyze
+    the default WP user.

--- a/man/wp-last-wp-logins-ng.md
+++ b/man/wp-last-wp-logins-ng.md
@@ -1,0 +1,32 @@
+---
+title: "wp-last-wp-logins-ng"
+---
+
+
+# NAME
+
+wp-last-wp-logins-ng - manual page for wp-last-wp-logins-ng git version
+fba2a66
+
+# DESCRIPTION
+
+usage: wp-last-wp-logins-ng \[-h\] \[--version\]
+
+  - \[--max-unsuccessful MAX\_UNSUCCESSFUL\]  
+    \[--max-days MAX\_DAYS\]
+
+'List last logins based on */data/log/wp-login*.log\*.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit
+
+  - **--max-unsuccessful** MAX\_UNSUCCESSFUL  
+    Display at maximum given many unsuccessful logins
+
+  - **--max-days** MAX\_DAYS  
+    Read at least given many days logs

--- a/man/wp-last-wp-logins.md
+++ b/man/wp-last-wp-logins.md
@@ -1,0 +1,23 @@
+---
+title: "wp-last-wp-logins"
+---
+
+
+# NAME
+
+wp-last-wp-logins - manual page for wp-last-wp-logins git version
+fba2a66
+
+# DESCRIPTION
+
+usage: wp-last-wp-logins \[options\]
+
+List last logins based on wp-login.log
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit

--- a/man/wp-list-env.md
+++ b/man/wp-list-env.md
@@ -1,0 +1,25 @@
+---
+title: "wp-list-env"
+---
+
+
+# NAME
+
+wp-list-env - manual page for wp-list-env git version fba2a66
+
+# SYNOPSIS
+
+**wp-list-env** \[*-h*\] \[*--version*\]
+
+# DESCRIPTION
+
+List environment variables that affect the WordPress installation at
+*/data/wordpress*
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit

--- a/man/wp-list-files-ctime.md
+++ b/man/wp-list-files-ctime.md
@@ -1,0 +1,33 @@
+---
+title: "wp-list-files-ctime"
+---
+
+
+# NAME
+
+wp-list-files-ctime - manual page for wp-list-files-ctime git version
+fba2a66
+
+# DESCRIPTION
+
+usage: wp-list-files-ctime \[options\]
+
+List all recently changed filed based on ctime. This is less reliable
+then wp-backup-list-changes as files can have their ctime attribute set
+to anything.
+
+## optional arguments:
+
+  - **-c**  
+    code investigation **-mode**, ignore image and binary translation
+    files
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit
+
+# SEE ALSO
+
+*wp-backup-list-changes*(1)

--- a/man/wp-list-files-mtime.md
+++ b/man/wp-list-files-mtime.md
@@ -1,0 +1,33 @@
+---
+title: "wp-list-files-mtime"
+---
+
+
+# NAME
+
+wp-list-files-mtime - manual page for wp-list-files-mtime git version
+fba2a66
+
+# DESCRIPTION
+
+usage: wp-list-files-mtime \[options\]
+
+List all recently changed filed based on mtime. This is less reliable
+then wp-backup-list-changes as files can have their mtime attribute set
+to anything.
+
+## optional arguments:
+
+  - **-c**  
+    code investigation **-mode**, ignore image and binary translation
+    files
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit
+
+# SEE ALSO
+
+*wp-backup-list-changes*(1)

--- a/man/wp-load-test-ng.md
+++ b/man/wp-load-test-ng.md
@@ -1,0 +1,85 @@
+---
+title: "wp-load-test-ng"
+---
+
+
+# NAME
+
+wp-load-test-ng - manual page for wp-load-test-ng git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-load-test-ng \[-h\] \[--version\] \[--cache\] \[--initial-qps
+INITIAL\_QPS\]
+
+  - \[--interval INTERVAL\]  
+    \[--latency \[LATENCIES \[LATENCIES ...\]\]\] \[--max-logs
+    MAX\_LOGS\] \[--max-qps MAX\_QPS\] \[--use-nginx-logs\] \[--num-bots
+    NUM\_BOTS\] \[--num-intervals NUM\_INTERVALS\]
+    \[--num-failed-intervals NUM\_FAILED\_INTERVALS\] \[--qps-add
+    QPS\_ADD\] \[--safe-time SAFE\_TIME\] \[--url-file URL\_FILE\] \[url
+    \[url ...\]\]
+
+Simple loadtesting tool for WordPress sites.
+
+## positional arguments:
+
+  - url  
+    Site URL to the target site.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit
+
+  - **--cache**  
+    If **--cache** is not used, "Pragma: no-cache" header is set.
+
+  - **--initial-qps** INITIAL\_QPS  
+    Initial total QPS from all load bots.
+
+  - **--interval** INTERVAL  
+    Duration of a round.
+
+  - **--latency** \[LATENCIES \[LATENCIES ...\]\]  
+    Set latency requirement **--latency**=*percentile*,max\_latency
+    where percentile is a float in range \[0, 100\] and max\_latency is
+    a positive value in seconds (float). Example: **--latency**=*99*,2.5
+    means that the 99th percentile latency should be less than 2.5s.
+    percentile == 100 means maximum latency. This option can be used
+    many times to specify multiple latency requirements. E.g.
+    simultaneously set both median and maximum latency.
+
+  - **--max-logs** MAX\_LOGS  
+    Maximum number of URLs to replay. Zero means no limit.
+
+  - **--max-qps** MAX\_QPS  
+    Total maximum QPS from all load bots.
+
+  - **--use-nginx-logs**  
+    Use nginx logs for load test. Read all HTTP GET requests with status
+    code 200.
+
+  - **--num-bots** NUM\_BOTS  
+    Set the number of load bots sending traffic to the target site
+
+  - **--num-intervals** NUM\_INTERVALS  
+    Send constant QPS for given amount of intervals (each interval with
+    duration given by **--interval**) before ramping up QPS.
+
+  - **--num-failed-intervals** NUM\_FAILED\_INTERVALS  
+    Report failure if load test criteria are not met in given many
+    consecutive intervals.
+
+  - **--qps-add** QPS\_ADD  
+    Increase load in steps of given QPS.
+
+  - **--safe-time** SAFE\_TIME  
+    Wait given many seconds before starting the load test.
+
+  - **--url-file** URL\_FILE  
+    Path to file containing one URL per line. Empty lines and lines
+    beginning with \# are ignored.

--- a/man/wp-load-test.md
+++ b/man/wp-load-test.md
@@ -1,0 +1,35 @@
+---
+title: "wp-load-test"
+---
+
+
+# NAME
+
+wp-load-test - manual page for wp-load-test git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-load-test \[--cache\] \[-h\] \[--version\] \[URL\]
+
+wp-load-test is a simple command line tool to measure many consecutive
+PHP requests the site can handle in a minute while still serving each
+request in under 5 seconds. This test only uses a single PHP worker and
+it bypasses the edge cache. The actual site will be capable of handling
+much more traffic. If the response time of a single PHP request is much
+above 0.500 seconds, please try to optimize the PHP code and run
+wp-speed-test. If the response time is much below 0.100 seconds, then
+this test is likely to trigger the flood protection and server will
+yield 429 responses.
+
+Defaults to using output of wp-url if URL argument is not given.
+
+## optional arguments:
+
+  - **--cache**  
+    Measures cached results. This does not measure actual PHP speed.
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit

--- a/man/wp-mail-test.md
+++ b/man/wp-mail-test.md
@@ -1,0 +1,23 @@
+---
+title: "wp-mail-test"
+---
+
+
+# NAME
+
+wp-mail-test - manual page for wp-mail-test git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-mail-test \[-h\] \[--version\] to \[from\]
+
+A simple command line tool to test that mail() works as expected.
+Combine with mail-tester.com for most comprehensive results.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit

--- a/man/wp-makepot.md
+++ b/man/wp-makepot.md
@@ -1,0 +1,20 @@
+---
+title: "wp-makepot"
+---
+
+
+# NAME
+
+wp-makepot - manual page for wp-makepot git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-makepot \[options\]
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit

--- a/man/wp-network-status.md
+++ b/man/wp-network-status.md
@@ -1,0 +1,23 @@
+---
+title: "wp-network-status"
+---
+
+
+# NAME
+
+wp-network-status - manual page for wp-network-status git version
+fba2a66
+
+# DESCRIPTION
+
+usage: wp-network-status \[options\]
+
+List status of WordPress Network.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit

--- a/man/wp-optimize-images.md
+++ b/man/wp-optimize-images.md
@@ -1,0 +1,58 @@
+---
+title: "wp-optimize-images"
+---
+
+
+# NAME
+
+wp-optimize-images - manual page for wp-optimize-images git version
+fba2a66
+
+# DESCRIPTION
+
+usage: wp-optimize-images \[-h\] \[--version\] \[--enable\]
+
+  - \[--set-max-resolution-width MAX\_RESOLUTION\_WIDTH\]  
+    \[--set-max-resolution-height MAX\_RESOLUTION\_HEIGHT\] \[-f\]
+    \[--strip-metadata\] \[path\]
+
+Optimize images on a WordPress site. Can be given a path, scans
+\*/data/wordpress/htdocs/wp-content/uploads/\* as default. Runs only if
+the \*seravo-enable-optimize-images\* value in the database is set to
+true. Reduces the resolution of all JPEG files according to maximum
+width and height saved in the datadase. Maximum image quality for JPEG
+is set to 90. Image quality for PNG files is set to 7. Prints the output
+to terminal and */data/log/wpoptimize-images.log*
+
+## positional arguments:
+
+  - path  
+    File or directory of images to optimize
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit
+
+  - **--enable**  
+    Enable image optimization even if seravo-enableoptimize-images is
+    not "on"
+
+  - **--set-max-resolution-width** MAX\_RESOLUTION\_WIDTH  
+    Set to override seravo-image-max-resolution-width.
+
+  - **--set-max-resolution-height** MAX\_RESOLUTION\_HEIGHT  
+    Set to override seravo-image-max-resolution-height.
+
+  - **-f**, **--force**  
+    Force optimization.
+
+  - **--strip-metadata**  
+    Remove metadata from images
+
+# SEE ALSO
+
+*jpegoptim*(1), *optipng*(1)

--- a/man/wp-php-compatibility-check.md
+++ b/man/wp-php-compatibility-check.md
@@ -1,0 +1,36 @@
+---
+title: "wp-php-compatibility-check"
+---
+
+
+# NAME
+
+wp-php-compatibility-check - manual page for wp-php-compatibility-check
+git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-php-compatibility-check \[-h\] \[--version\] \[path
+\[phpversion\]\]
+
+Check that the PHP code of the current WordPress installation, including
+themes and plugins, is compatible with the PHP specified.
+
+This is based on phpcs and it's PHP compatibility rulesets.
+
+## positional arguments:
+
+  - path  
+    Path to site. Defaults to
+    */data/wordpress/htdocs/wordpress/wp-content*
+
+  - phpversion  
+    PHP version. Defaults to 7.4.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit

--- a/man/wp-php-slowlog.md
+++ b/man/wp-php-slowlog.md
@@ -1,0 +1,29 @@
+---
+title: "wp-php-slowlog"
+---
+
+
+# NAME
+
+wp-php-slowlog - manual page for wp-php-slowlog git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-php-slowlog \[-e\] \[-d\] \[-h\] \[--version\]
+
+Enable/disable logging for long-running PHP requests. When enabled, will
+log slow PHP runs for 3 hours.
+
+## optional arguments:
+
+  - **-e**, **--enable**  
+    enable PHP slowlog
+
+  - **-d**, **--disable**  
+    disable PHP slowlog
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit

--- a/man/wp-pomo-compile.md
+++ b/man/wp-pomo-compile.md
@@ -1,0 +1,31 @@
+---
+title: "wp-pomo-compile"
+---
+
+
+# NAME
+
+wp-pomo-compile - manual page for wp-pomo-compile git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-pomo-compile \[-h\] \[--version\] \[path\]
+
+Compile clear text PO translation files into binary MO files.
+
+## positional arguments:
+
+  - path  
+    Path to wp-content. Defaults to */data/wordpress/htdocs/wp-content*.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit
+
+# SEE ALSO
+
+*msgfmt*(1), *wp-makepot*(1), *wp i18n*(1)

--- a/man/wp-pull-production-core.md
+++ b/man/wp-pull-production-core.md
@@ -1,0 +1,23 @@
+---
+title: "wp-pull-production-core"
+---
+
+
+# NAME
+
+wp-pull-production-core - manual page for wp-pull-production-core git
+version fba2a66
+
+# DESCRIPTION
+
+usage: wp-pull-production-core \[-h\] \[--version\]
+
+Install the same WordPress core version as on production site.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit

--- a/man/wp-pull-production-db.md
+++ b/man/wp-pull-production-db.md
@@ -1,0 +1,23 @@
+---
+title: "wp-pull-production-db"
+---
+
+
+# NAME
+
+wp-pull-production-db - manual page for wp-pull-production-db git
+version fba2a66
+
+# DESCRIPTION
+
+usage: wp-pull-production-db \[-h\] \[--version\]
+
+Pull database from production site.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit

--- a/man/wp-pull-production-plugins.md
+++ b/man/wp-pull-production-plugins.md
@@ -1,0 +1,23 @@
+---
+title: "wp-pull-production-plugins"
+---
+
+
+# NAME
+
+wp-pull-production-plugins - manual page for wp-pull-production-plugins
+git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-pull-production-plugins \[-h\] \[--version\]
+
+Pull plugins from production site.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit

--- a/man/wp-pull-production-themes.md
+++ b/man/wp-pull-production-themes.md
@@ -1,0 +1,23 @@
+---
+title: "wp-pull-production-themes"
+---
+
+
+# NAME
+
+wp-pull-production-themes - manual page for wp-pull-production-themes
+git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-pull-production-themes \[-h\] \[--version\]
+
+Pull themes from production site.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit

--- a/man/wp-pull-shadow-db.md
+++ b/man/wp-pull-shadow-db.md
@@ -1,0 +1,23 @@
+---
+title: "wp-pull-shadow-db"
+---
+
+
+# NAME
+
+wp-pull-shadow-db - manual page for wp-pull-shadow-db git version
+0d7fbd7
+
+# DESCRIPTION
+
+usage: wp-pull-shadow-db \[-h\] \[--version\]
+
+Pull database from shadow site.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit

--- a/man/wp-pull-staging-db.md
+++ b/man/wp-pull-staging-db.md
@@ -1,0 +1,23 @@
+---
+title: "wp-pull-staging-db"
+---
+
+
+# NAME
+
+wp-pull-staging-db - manual page for wp-pull-staging-db git version
+fba2a66
+
+# DESCRIPTION
+
+usage: wp-pull-staging-db \[-h\] \[--version\]
+
+Pull database from shadow site.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit

--- a/man/wp-purge-cache.md
+++ b/man/wp-purge-cache.md
@@ -1,0 +1,30 @@
+---
+title: "wp-purge-cache"
+---
+
+
+# NAME
+
+wp-purge-cache - manual page for wp-purge-cache git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-purge-cache \[options\]
+
+Purge nginx proxy cache, WordPress object cache, WordPress rewrite cache
+and PageSpeed cache. Restart nginx.
+
+Note: wp-purge-cache does nothing in a development environment. It is
+only effective in production/staging (shadow).
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit
+
+# SEE ALSO
+
+*wp-flush-cache*(1)

--- a/man/wp-reload-nginx.md
+++ b/man/wp-reload-nginx.md
@@ -1,0 +1,30 @@
+---
+title: "wp-reload-nginx"
+---
+
+
+# NAME
+
+wp-reload-nginx - manual page for wp-reload-nginx git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-reload-nginx \[-h\] \[--version\]
+
+Reload Nginx configuration. If the configuration is invalid, the script
+returns with error and Nginx continues with the old (valid) config.
+
+Note: User specific Nginx configuration is located at
+/data/wordpress/nginx/\*.conf.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit
+
+# SEE ALSO
+
+*wp-restart-nginx*(1)

--- a/man/wp-remote-db-on.md
+++ b/man/wp-remote-db-on.md
@@ -1,0 +1,25 @@
+---
+title: "wp-remote-db-on"
+---
+
+
+# NAME
+
+wp-remote-db-on - manual page for wp-remote-db-on git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-remote-db-on \[-h\] \[--version\]
+
+Enable Vagrant MariaDB server to accept connections from developer
+tools. This is a potential security issue. A malicious attacker on your
+local network who knows the database credentials might gain remote
+access.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit

--- a/man/wp-reset-all-passwords.md
+++ b/man/wp-reset-all-passwords.md
@@ -1,0 +1,39 @@
+---
+title: "wp-reset-all-passwords"
+---
+
+
+# NAME
+
+wp-reset-all-passwords - manual page for wp-reset-all-passwords git
+version fba2a66
+
+# DESCRIPTION
+
+usage: wp-reset-all-passwords \[-h\] \[--version\] \[--force\] \[--roles
+ROLES\]
+
+> \[--send-email\]
+
+Reset passwords of all users. Reset passwords for all WordPress users.
+Users are sent an automatic password reset notification email if
+**--send-email** is used.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit
+
+  - **--force**, **--yes**  
+    Do not ask for confirmation
+
+  - **--roles** ROLES  
+    Reset passwords for all users that match the given comma separated
+    list of roles. Reset passwords for all users if 'all' is given. This
+    is the default.
+
+  - **--send-email**  
+    Send email to each user whose password is reset

--- a/man/wp-reset-all-sessions.md
+++ b/man/wp-reset-all-sessions.md
@@ -1,0 +1,23 @@
+---
+title: "wp-reset-all-sessions"
+---
+
+
+# NAME
+
+wp-reset-all-sessions - manual page for wp-reset-all-sessions git
+version fba2a66
+
+# DESCRIPTION
+
+usage: wp-reset-all-sessions \[-h\] \[--version\]
+
+Reset all sessions for all WordPress users.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit

--- a/man/wp-reset-ssh-password.md
+++ b/man/wp-reset-ssh-password.md
@@ -1,0 +1,23 @@
+---
+title: "wp-reset-ssh-password"
+---
+
+
+# NAME
+
+wp-reset-ssh-password - manual page for wp-reset-ssh-password git
+version fba2a66
+
+# DESCRIPTION
+
+usage: wp-reset-ssh-password \[-h\] \[--version\]
+
+Reset all ssh passwords.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit

--- a/man/wp-restart-db.md
+++ b/man/wp-restart-db.md
@@ -1,0 +1,24 @@
+---
+title: "wp-restart-db"
+---
+
+
+# NAME
+
+wp-restart-db - manual page for wp-restart-db git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-restart-db \[-h\] \[--version\]
+
+Restart connections to the database. Any connections that are taking too
+long or are stuck will be stopped during the restarting of database
+connections.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit

--- a/man/wp-restart-nginx.md
+++ b/man/wp-restart-nginx.md
@@ -1,0 +1,37 @@
+---
+title: "wp-restart-nginx"
+---
+
+
+# NAME
+
+wp-restart-nginx - manual page for wp-restart-nginx git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-restart-nginx \[-h\] \[--quiet\] \[--version\]
+
+Restart Nginx. The tool first shows what would change in the new
+configuration unless **--quiet** is given. Then it validates the
+configuration. If the configuration is invalid, the tool returns with
+error. If configuration is valid, PHP is restarted with wp-php-restart.
+Then Nginx is restarted, briefly interrupting the service (i.e. clients
+can experience errors).
+
+Note: User specific Nginx configuration is located at
+/data/wordpress/nginx/\*.conf.
+
+## optional arguments:
+
+  - **--quiet**  
+    do not display configuration changes
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit
+
+# SEE ALSO
+
+*wp-reload-nginx*(1), *wp-restart-php*(1)

--- a/man/wp-restart-php.md
+++ b/man/wp-restart-php.md
@@ -1,0 +1,26 @@
+---
+title: "wp-restart-php"
+---
+
+
+# NAME
+
+wp-restart-php - manual page for wp-restart-php git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-restart-php \[-h\] \[--quiet\] \[--version\]
+
+Restart all PHP processes. Any PHP running that is stuck, will be thus
+down.
+
+## optional arguments:
+
+  - **--quiet**  
+    Do not show config changes
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit

--- a/man/wp-seravo-plugin-update.md
+++ b/man/wp-seravo-plugin-update.md
@@ -1,0 +1,31 @@
+---
+title: "wp-seravo-plugin-update"
+---
+
+
+# NAME
+
+wp-seravo-plugin-update - manual page for wp-seravo-plugin-update git
+version fba2a66
+
+# DESCRIPTION
+
+usage: wp-seravo-plugin-update \[-h\] \[--version\] \[--dev\]
+\[--reinstall\]
+
+Update the must-use seravo-plugin to the latest version. It also cleans
+up all legacy remnants of the wp-palvelu-plugin.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit
+
+  - **--dev**  
+    Install the latest Git version
+
+  - **--reinstall**  
+    Reinstall the plugin even if the latest version is already installed

--- a/man/wp-shadow-pull.md
+++ b/man/wp-shadow-pull.md
@@ -1,0 +1,44 @@
+---
+title: "wp-shadow-pull"
+---
+
+
+# NAME
+
+wp-shadow-pull - manual page for wp-shadow-pull git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-shadow-pull \[-h\] \[--version\] \[--force\]
+\[shadow\_to\_pull\]
+
+Move data from production to shadow instances. Given a shadow the tool
+will overwrite almost all of the files located in the path
+/data/wordpress/ on your production site. You may choose to import the
+database from the shadow when given a user prompt. Before executing the
+import, wp-shadow-pull creates a backup of your production environment.
+Using this script can lead to some of your data being lost or your
+production site breaking. Use only if you are a developer and/or
+confident that you really want to replace the current files in
+production with files from the shadow environment. Lists all available
+shadows when called with no arguments.
+
+## positional arguments:
+
+  - shadow\_to\_pull  
+    Name of the shadow to pull
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit
+
+  - **--force**  
+    Skip all user prompts, convenient for script usage
+
+# SEE ALSO
+
+*wp-shadow-reset*(1), *wp-backup*(1)

--- a/man/wp-shadow-reset.md
+++ b/man/wp-shadow-reset.md
@@ -1,0 +1,37 @@
+---
+title: "wp-shadow-reset"
+---
+
+
+# NAME
+
+wp-shadow-reset - manual page for wp-shadow-reset git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-shadow-reset \[-h\] \[--version\] \[--force\]
+\[shadow\_to\_reset\]
+
+Move data from production to shadow instances. Delete and replace all
+files in the /data/wordpress/ directory of a shadow with a clone from
+production.
+
+## positional arguments:
+
+  - shadow\_to\_reset  
+    Name of the shadow to reset
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit
+
+  - **--force**  
+    Skip user prompt
+
+# SEE ALSO
+
+*wp-shadow-pull*(1), *wp-backup*(1)

--- a/man/wp-speed-test.md
+++ b/man/wp-speed-test.md
@@ -1,0 +1,35 @@
+---
+title: "wp-speed-test"
+---
+
+
+# NAME
+
+wp-speed-test - manual page for wp-speed-test git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-speed-test \[--cache\] \[-h\] \[--version\] \[URL\]
+
+wp-speed-test measures the load time of PHP responses.
+
+## positional arguments:
+
+  - URL  
+    The site URL to be tested. Defaults to using output of wp-url if the
+    argument is not given.
+
+## optional arguments:
+
+  - **--cache**  
+    Measures cached results. This does not measure actual PHP speed.
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit
+
+# SEE ALSO
+
+*wp-load-test*(1)

--- a/man/wp-ssh-production.md
+++ b/man/wp-ssh-production.md
@@ -1,0 +1,23 @@
+---
+title: "wp-ssh-production"
+---
+
+
+# NAME
+
+wp-ssh-production - manual page for wp-ssh-production git version
+fba2a66
+
+# DESCRIPTION
+
+usage: wp-ssh-production \[-h\] \[--version\]"
+
+SSH into production container.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit

--- a/man/wp-static-export.md
+++ b/man/wp-static-export.md
@@ -1,0 +1,35 @@
+---
+title: "wp-static-export"
+---
+
+
+# NAME
+
+wp-static-export - manual page for wp-static-export git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-static-export \[-h\] \[--version\] \[URL \[OUTPUT\_DIR\]\]
+
+Export a static version of the site. All pages and assets of the
+WordPress site will be crawled and saved as static HTML files, which
+might be useful in certain static file use cases.
+
+Note\! This tool is experimental and currently useful only to developers
+who will further process the static files generated at */data/static*.
+
+## positional arguments:
+
+  - URL  
+    Site URL to export. Defaults to the output of wp-url command.
+
+  - OUTPUT\_DIR  
+    Defaults to */data/static*.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit

--- a/man/wp-test-ng.md
+++ b/man/wp-test-ng.md
@@ -1,0 +1,42 @@
+---
+title: "wp-test-ng"
+---
+
+
+# NAME
+
+wp-test-ng - manual page for wp-test-ng git version 0d7fbd7
+
+# SYNOPSIS
+
+**wp-test-ng** \[*-h*\] \[*--version*\] \[*--insecure*\] \[*--debug*\]
+\[*--fail-fast*\]
+
+# DESCRIPTION
+
+Test that the WordPress installation works. Runs a set of standard
+Seravo tests and any custom tests the site might have. Note, that if the
+standard set of tests fail, user-provided tests will not be run at all.
+
+For full documentation please read
+https://seravo.com/docs/tests/ng-integration-tests/
+
+Based on Codeception PHP testing framework. Any additional arguments are
+passed as-is to 'codecept'.
+
+## optional arguments:
+
+  - **--insecure**  
+    ignore HTTPS certificate issues
+
+  - **--fail-fast**  
+    stop tests on first error that occurred
+
+  - **--debug**  
+    display verbose debug information
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit

--- a/man/wp-test-whitelist.md
+++ b/man/wp-test-whitelist.md
@@ -1,0 +1,65 @@
+---
+title: "wp-test-whitelist"
+---
+
+
+# NAME
+
+wp-test-whitelist - manual page for wp-test-whitelist git version
+fba2a66
+
+# DESCRIPTION
+
+usage: Command for whitelisting wp-test errors and warnings
+
+Whitelist Chrome developer console errors so that they don't get caught
+when running wp-test. Occasionally, the Chrome developer console outputs
+false positive errors that should just be ignored by wp-test.
+
+You can whitelist an error output by either typing in the whole error
+string or whitelist many similar errors by utilizing regular expression.
+You can also specify, if the message you're whitelisting, is an error or
+a warning.
+
+Whitelist a single message
+
+> wp-test-whitelist **--add** "https://example.com/favicon.ico 404 (Not
+> Found)"
+
+Whitelist multiple errors with regex
+
+> wp-test-whitelist **--add** ".\*example\\.com/mylibrary\\.js.\*404.\*"
+> **--regex**
+
+## Read more about whitelisting:
+
+> https://seravo.com/docs/tests/ng-integration-tests/\#howto-whitelist-specific-harmless-chrome-console-errors
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit
+
+  - **--list**  
+    Show a list of whitelist entries
+
+  - **--add** MESSAGE  
+    Whitelist given message
+
+  - **--delete**  
+    Unwhitelist given message
+
+  - **--reset**  
+    Clear the whitelist
+
+  - **--error**  
+    Specify messages's level to be error
+
+  - **--warning**  
+    Specify messages's level to be warning
+
+  - **--regex**  
+    Use regular expression

--- a/man/wp-test.md
+++ b/man/wp-test.md
@@ -1,0 +1,42 @@
+---
+title: "wp-test"
+---
+
+
+# NAME
+
+wp-test - manual page for wp-test git version fba2a66
+
+# SYNOPSIS
+
+**wp-test** \[*-h*\] \[*--version*\] \[*--insecure*\] \[*--debug*\]
+\[*--fail-fast*\]
+
+# DESCRIPTION
+
+Test that the WordPress installation works. Runs a set of standard
+Seravo tests and any custom tests the site might have. Note, that if the
+standard set of tests fail, user-provided tests will not be run at all.
+
+For full documentation please read
+https://seravo.com/docs/tests/ng-integration-tests/
+
+Based on Codeception PHP testing framework. Any additional arguments are
+passed as-is to 'codecept'.
+
+## optional arguments:
+
+  - **--insecure**  
+    ignore HTTPS certificate issues
+
+  - **--fail-fast**  
+    stop tests on first error that occurred
+
+  - **--debug**  
+    display verbose debug information
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit

--- a/man/wp-theme-security-check.md
+++ b/man/wp-theme-security-check.md
@@ -1,0 +1,32 @@
+---
+title: "wp-theme-security-check"
+---
+
+
+# NAME
+
+wp-theme-security-check - manual page for wp-theme-security-check git
+version fba2a66
+
+# DESCRIPTION
+
+usage: wp-theme-security-check \[--force\] \[-h\] \[--version\]
+
+Check WordPress theme security with phpcs and log each run. Makes the
+check if a prior check has not been made or if files have been changed
+since last check.
+
+## optional arguments:
+
+  - **--force**  
+    Force running security check
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit
+
+# SEE ALSO
+
+*phpcs*(1)

--- a/man/wp-url.md
+++ b/man/wp-url.md
@@ -1,0 +1,24 @@
+---
+title: "wp-url"
+---
+
+
+# NAME
+
+wp-url - manual page for wp-url git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-url \[-h\] \[--version\]
+
+Print the URL of the WordPress website. Show what is the full URL to the
+WordPress site main page. For details see
+https://seravo.com/docs/configuration/redirect/\#understanding-the-differenceof-get\_home-and-get\_siteurl-in-wordpress
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit

--- a/man/wp-use-asset-proxy.md
+++ b/man/wp-use-asset-proxy.md
@@ -1,0 +1,27 @@
+---
+title: "wp-use-asset-proxy"
+---
+
+
+# NAME
+
+wp-use-asset-proxy - manual page for wp-use-asset-proxy git version
+0d7fbd7
+
+# DESCRIPTION
+
+usage: wp-use-asset-proxy \[-h\] \[--version\]
+
+Activate asset proxy to avoid need to download WordPress uploads
+directory. Update Nginx settings to that requests to
+/wp-content/uploads/\* are transparently proxied from the production
+site, eliminating the need to download the uploads directory from the
+production site to the local development site (or to shadow sites).
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    show this help message and exit
+
+  - **--version**  
+    show program's version number and exit

--- a/man/wp-vagrant-activation.md
+++ b/man/wp-vagrant-activation.md
@@ -1,0 +1,23 @@
+---
+title: "wp-vagrant-activation"
+---
+
+
+# NAME
+
+wp-vagrant-activation - manual page for wp-vagrant-activation git
+version fba2a66
+
+# DESCRIPTION
+
+usage: wp-vagrant-activation \[-h\] \[--version\]"
+
+Runs commands needed during vagrant up.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit

--- a/man/wp-vagrant-dump-db.md
+++ b/man/wp-vagrant-dump-db.md
@@ -1,0 +1,23 @@
+---
+title: "wp-vagrant-dump-db"
+---
+
+
+# NAME
+
+wp-vagrant-dump-db - manual page for wp-vagrant-dump-db git version
+fba2a66
+
+# DESCRIPTION
+
+usage: wp-vagrant-dump-db \[-h\] \[--version\]
+
+Dump WordPress DB into .vagrant folder.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit

--- a/man/wp-vagrant-import-db.md
+++ b/man/wp-vagrant-import-db.md
@@ -1,0 +1,23 @@
+---
+title: "wp-vagrant-import-db"
+---
+
+
+# NAME
+
+wp-vagrant-import-db - manual page for wp-vagrant-import-db git version
+fba2a66
+
+# DESCRIPTION
+
+usage: wp-vagrant-import-db \[-h\] \[--version\]
+
+Import WordPress DB from .vagrant folder.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit

--- a/man/wp-watch-logs.md
+++ b/man/wp-watch-logs.md
@@ -1,0 +1,22 @@
+---
+title: "wp-watch-logs"
+---
+
+
+# NAME
+
+wp-watch-logs - manual page for wp-watch-logs git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-watch-logs \[-h\] \[--version\]
+
+Start watching all the logs under /data/log/.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit

--- a/man/wp-xdebug-off.md
+++ b/man/wp-xdebug-off.md
@@ -1,0 +1,22 @@
+---
+title: "wp-xdebug-off"
+---
+
+
+# NAME
+
+wp-xdebug-off - manual page for wp-xdebug-off git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-xdebug-off \[-h\] \[--version\]
+
+Disable Xdebug in local development so that the site runs faster.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit

--- a/man/wp-xdebug-on.md
+++ b/man/wp-xdebug-on.md
@@ -1,0 +1,25 @@
+---
+title: "wp-xdebug-on"
+---
+
+
+# NAME
+
+wp-xdebug-on - manual page for wp-xdebug-on git version fba2a66
+
+# DESCRIPTION
+
+usage: wp-xdebug-on \[-h\] \[--version\]
+
+Enable Xdebug.
+
+Remember to disable Xdebug with 'wp-xdebug-off' when done
+debugging/profiling, since it slows down the WordPress site quite a lot.
+
+## optional arguments:
+
+  - **-h**, **--help**  
+    display this help and exit
+
+  - **--version**  
+    display version and exit


### PR DESCRIPTION
Add markdown files for the man pages of wp-* commands
and create links to them in the *List of commands* post.

Links created with find-replace:
```
  `([a-z-]*)` -      ->      [`$1`](/docs/man/$1) -
```

There is a fork with these changes that might help with testing:
 https://sjaks.github.io/docs/get-started/available-commands/

## Screenshots
Links:
![image](https://user-images.githubusercontent.com/44066308/91167144-21a6e200-e6dc-11ea-878f-12db9071320c.png)

Man page:
![image](https://user-images.githubusercontent.com/44066308/91167178-28cdf000-e6dc-11ea-9a75-d7cb3adbbdf0.png)
