### PR TITLE
Include man pages in search

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -21,7 +21,7 @@
       resultsContainer: document.getElementById('results-container'),
       json: '/docs/search.json',
       fuzzy: false,
-      searchResultTemplate: '<li><a href="{url}">{title}</a><small> in <strong>{category}</strong></small<div class="search-content" data-content={content}></div></li>',
+      searchResultTemplate: '<li><a href="{url}">{title}</a><small> in <strong>{category}</strong></small></li>',
       noResultsText: 'No results found, Sorry! Please try again or add an issue <a href="https://github.com/{{site.github.repo}}/issues/">in Github</a>.'
     });
   });

--- a/search.json
+++ b/search.json
@@ -11,5 +11,15 @@ layout: null
       "date"     : "{{ post.date }}",
       "content"  : {{ post.content | strip_html | strip_newlines | jsonify }}
     } {% unless forloop.last %},{% endunless %}
+  {% endfor %},
+  {% for page in site.pages %}
+    {
+      {% if page.title contains 'wp-' %}
+        "title"    : "{{ page.title | escape }}",
+        "category" : "man pages",
+        "url"      : "{{ site.baseurl }}{{ page.url }}",
+        "content"  : {{ page.content | strip_html | strip_newlines | jsonify }}
+      {% endif %}
+    } {% unless forloop.last %},{% endunless %}
   {% endfor %}
 ]


### PR DESCRIPTION
* Make man pages searchable by including them in `search.json`.
* Statically put them in a category man pages.

Disables the post and page content body from search results
since it wasn't loaded with the previous docs posts. Search
indexing the man pages introduced an issue where the content
filled a large portion of the search result box.

Closes: #47

## Screenshots
**Before man pages were not searchable and no body tags present:**
![image](https://user-images.githubusercontent.com/44066308/91179551-53757400-e6ef-11ea-8d19-05c922a634f2.png)

**Now man pages are found:**
![image](https://user-images.githubusercontent.com/44066308/91179601-64be8080-e6ef-11ea-820f-e4e85fdd6fa2.png)
![image](https://user-images.githubusercontent.com/44066308/91179635-743dc980-e6ef-11ea-960d-45a3f09a3d4d.png)

These changes are present in here: https://sjaks.github.io/docs/