### PR TITLE
Update man pages and use new md format

### DIFF
--- a/man/wp-activate-asset-proxy.md
+++ b/man/wp-activate-asset-proxy.md
@@ -3,14 +3,16 @@ title: "wp-activate-asset-proxy"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-activate-asset-proxy - manual page for wp-activate-asset-proxy git
-version fba2a66
+version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-activate-asset-proxy \[-h\] \[--version\]
+usage: wp-activate-asset-proxy \[-h\] \[\--version\]
 
 Activate asset proxy to avoid need to download WordPress uploads
 directory. Update Nginx settings to that requests to
@@ -18,10 +20,13 @@ directory. Update Nginx settings to that requests to
 site, eliminating the need to download the uploads directory from the
 production site to the local development site (or to shadow sites).
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    show this help message and exit
+**-h**, **\--help**
 
-  - **--version**  
-    show program's version number and exit
+:   show this help message and exit
+
+**\--version**
+
+:   show program\'s version number and exit

--- a/man/wp-activate-git-hooks.md
+++ b/man/wp-activate-git-hooks.md
@@ -3,21 +3,26 @@ title: "wp-activate-git-hooks"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-activate-git-hooks - manual page for wp-activate-git-hooks git
-version fba2a66
+version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
 usage: wp-activate-git-hooks \[options\]
 
 Active githooks in scripts folder.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    display this help and exit
+**-h**, **\--help**
 
-  - **--version**  
-    display version and exit
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit

--- a/man/wp-backup-list-changes-ng.md
+++ b/man/wp-backup-list-changes-ng.md
@@ -3,33 +3,39 @@ title: "wp-backup-list-changes-ng"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-backup-list-changes-ng - manual page for wp-backup-list-changes-ng
-git version fba2a66
+git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-backup-list-changes-ng \[-h\] \[--version\]
+usage: wp-backup-list-changes-ng \[-h\] \[\--version\]
 
-> \[--increments-dir INCREMENTS\_DIR\]
+> \[\--increments-dir INCREMENTS\_DIR\]
 
 Lists all files known by rdiff-backup sorted by timestamp. Use this to
 find out what files really changed in the system, as the file attribute
-mtime is not a reliable source of information. "." before filename
-indicates the file was modified. "+" before filename indicates the file
-was added. "-" before filename indicates the file was removed. Use
-'rdiff-backup **--exclude** */data/backups* **--compare-at-time** now
-*/data* /data/backs/data/' to find out how the current data differs from
-latest backup.
+mtime is not a reliable source of information. \".\" before filename
+indicates the file was modified. \"+\" before filename indicates the
+file was added. \"-\" before filename indicates the file was removed.
+Use \'rdiff-backup **\--exclude** */data/backups* **\--compare-at-time**
+now */data* /data/backs/data/\' to find out how the current data differs
+from latest backup.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    show this help message and exit
+**-h**, **\--help**
 
-  - **--version**  
-    show program's version number and exit
+:   show this help message and exit
 
-  - **--increments-dir** INCREMENTS\_DIR  
-    rdiff-backup directory containing increments
+**\--version**
+
+:   show program\'s version number and exit
+
+**\--increments-dir** INCREMENTS\_DIR
+
+:   rdiff-backup directory containing increments

--- a/man/wp-backup-list-changes-since.md
+++ b/man/wp-backup-list-changes-since.md
@@ -3,29 +3,36 @@ title: "wp-backup-list-changes-since"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-backup-list-changes-since - manual page for
-wp-backup-list-changes-since git version fba2a66
+wp-backup-list-changes-since git version 8235fae
 
-# SYNOPSIS
+SYNOPSIS
+========
 
-**wp-backup-list-changes-since** \[*-h*\] \[*--version*\] *\<time
+**wp-backup-list-changes-since** \[*-h*\] \[*\--version*\] *\<time
 string\>*
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-List files changed since given date, e.g. '2020-08-13'.
+List files changed since given date, e.g. \'2020-08-13\'.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    display this help and exit
+**-h**, **\--help**
 
-  - **--version**  
-    display version and exit
+:   display this help and exit
 
-# SEE ALSO
+**\--version**
+
+:   display version and exit
+
+SEE ALSO
+========
 
 *wp-backup-list-changes*(1), *wp-list-files-mtime*(1), *wp-db-dump*(1),
 *rdiff-backup*(1)

--- a/man/wp-backup-list-changes.md
+++ b/man/wp-backup-list-changes.md
@@ -3,40 +3,47 @@ title: "wp-backup-list-changes"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-backup-list-changes - manual page for wp-backup-list-changes git
-version fba2a66
+version 8235fae
 
-# SYNOPSIS
+SYNOPSIS
+========
 
-**wp-backup-list-changes** \[*-h*\] \[*--version*\]
-\[*--skip-database*\]
+**wp-backup-list-changes** \[*-h*\] \[*\--version*\]
+\[*\--skip-database*\]
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
 Lists all files known by rdiff-backup sorted by timestamp.
 
 Use this to find out what files really changed in the system, as the
 file attribute mtime is not a reliable source of information.
 
-For more detailed information, use 'rdiff-backup' commands directly.
+For more detailed information, use \'rdiff-backup\' commands directly.
 
 For example, to find out how the current data differs from latest backup
 run:
 
-> rdiff-backup **--exclude** */data/backups* **--compare-at-time** now
+> rdiff-backup **\--exclude** */data/backups* **\--compare-at-time** now
 > */data* /data/backs/data/
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    display this help and exit
+**-h**, **\--help**
 
-  - **--version**  
-    display version and exit
+:   display this help and exit
 
-# SEE ALSO
+**\--version**
+
+:   display version and exit
+
+SEE ALSO
+========
 
 *wp-backup-list-changes-since*(1), *wp-list-files-mtime*(1),
 *wp-db-dump*(1), *rdiff-backup*(1)

--- a/man/wp-backup-status.md
+++ b/man/wp-backup-status.md
@@ -3,11 +3,13 @@ title: "wp-backup-status"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-backup-status - manual page for wp-backup-status git version fba2a66
+wp-backup-status - manual page for wp-backup-status git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
 usage: wp-backup-status \[options\]
 
@@ -16,16 +18,20 @@ List all backup increments currently available.
 wp-backup-status is a shell program which lists all increments echo
 known by rdiff-backup sorted by timestamp. Use this to find out what
 kind of backups you are able to restore. This is an alias of
-"rdiff-backup **--list-increment-sizes** /data/backups/data".
+\"rdiff-backup **\--list-increment-sizes** /data/backups/data\".
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    display this help and exit
+**-h**, **\--help**
 
-  - **--version**  
-    display version and exit
+:   display this help and exit
 
-# SEE ALSO
+**\--version**
+
+:   display version and exit
+
+SEE ALSO
+========
 
 *wp-backup-status*(1), *wp-backup*(1), *rdiff-backup*(1)

--- a/man/wp-backup.md
+++ b/man/wp-backup.md
@@ -3,35 +3,43 @@ title: "wp-backup"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-backup - manual page for wp-backup git version fba2a66
+wp-backup - manual page for wp-backup git version 8235fae
 
-# SYNOPSIS
+SYNOPSIS
+========
 
-**wp-backup** \[*-h*\] \[*--version*\] \[*--skip-database*\]
+**wp-backup** \[*-h*\] \[*\--version*\] \[*\--skip-database*\]
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
 Makes a backup of the entire */data* directory into
 */data/backups/data*.
 
 The backup includes all WordPress files and a fresh database dump.
 
-Based on 'rdiff-backup' with some additional logic.
+Based on \'rdiff-backup\' with some additional logic.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **--skip-database**  
-    skip making a fresh database dump and only backup files
+**\--skip-database**
 
-  - **-h**, **--help**  
-    display this help and exit
+:   skip making a fresh database dump and only backup files
 
-  - **--version**  
-    display version and exit
+**-h**, **\--help**
 
-# SEE ALSO
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit
+
+SEE ALSO
+========
 
 *wp-backup-list-changes*(1), *wp-backup-list-changes-since*(1), *wp
 db*(1), *wp-db-dump*(1), *rdiff-backup*(1)

--- a/man/wp-check-haveibeenpwned.md
+++ b/man/wp-check-haveibeenpwned.md
@@ -3,30 +3,38 @@ title: "wp-check-haveibeenpwned"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-check-haveibeenpwned - manual page for wp-check-haveibeenpwned git
-version fba2a66
+version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-check-haveibeenpwned \[-h\] \[--version\] \[--json\] passhash
+usage: wp-check-haveibeenpwned \[-h\] \[\--version\] \[\--json\]
+passhash
 
 Quick pwnedpasswords.com checker. Using
 https://haveibeenpwned.com/API/v3\#SearchingPwnedPasswordsByRange Has
 both cli and JSON interface and can be used via Seravo Plugin.
 
-## positional arguments:
+positional arguments:
+---------------------
 
-  - passhash  
-    SHA1 of password
+passhash
 
-## optional arguments:
+:   SHA1 of password
 
-  - **-h**, **--help**  
-    show this help message and exit
+optional arguments:
+-------------------
 
-  - **--version**  
-    show program's version number and exit
+**-h**, **\--help**
 
-**--json**
+:   show this help message and exit
+
+**\--version**
+
+:   show program\'s version number and exit
+
+**\--json**

--- a/man/wp-check-http-cache.md
+++ b/man/wp-check-http-cache.md
@@ -3,32 +3,40 @@ title: "wp-check-http-cache"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-check-http-cache - manual page for wp-check-http-cache git version
-fba2a66
+8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-check-http-cache \[-h\] \[--version\] \[--no-https-verify\]
+usage: wp-check-http-cache \[-h\] \[\--version\] \[\--no-https-verify\]
 \[url\]
 
 Seravo HTTP cache checker.
 
-## positional arguments:
+positional arguments:
+---------------------
 
-  - url  
-    The URL you want to check. If not provided, the command will attempt
+url
+
+:   The URL you want to check. If not provided, the command will attempt
     to construct the URL using the domain from the WordPress
     installation.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    show this help message and exit
+**-h**, **\--help**
 
-  - **--version**  
-    show program's version number and exit
+:   show this help message and exit
 
-  - **--no-https-verify**  
-    Do not verify https request certificate.
+**\--version**
+
+:   show program\'s version number and exit
+
+**\--no-https-verify**
+
+:   Do not verify https request certificate.

--- a/man/wp-check-https.md
+++ b/man/wp-check-https.md
@@ -3,20 +3,25 @@ title: "wp-check-https"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-check-https - manual page for wp-check-https git version fba2a66
+wp-check-https - manual page for wp-check-https git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-check-https \[-h\] \[--version\]
+usage: wp-check-https \[-h\] \[\--version\]
 
 Seravo HTTP(S) checker tool.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    show this help message and exit
+**-h**, **\--help**
 
-  - **--version**  
-    show program's version number and exit
+:   show this help message and exit
+
+**\--version**
+
+:   show program\'s version number and exit

--- a/man/wp-check-loginurl.md
+++ b/man/wp-check-loginurl.md
@@ -3,22 +3,28 @@ title: "wp-check-loginurl"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-check-loginurl - manual page for wp-check-loginurl git version
-fba2a66
+8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-check-loginurl \[-h\] \[--version\] \[-p\]
+usage: wp-check-loginurl \[-h\] \[\--version\] \[-p\]
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    show this help message and exit
+**-h**, **\--help**
 
-  - **--version**  
-    show program's version number and exit
+:   show this help message and exit
 
-  - **-p**, **--only-path**  
-    Return only path (default: full URL).
+**\--version**
+
+:   show program\'s version number and exit
+
+**-p**, **\--only-path**
+
+:   Return only path (default: full URL).

--- a/man/wp-check-passwords.md
+++ b/man/wp-check-passwords.md
@@ -3,26 +3,32 @@ title: "wp-check-passwords"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-check-passwords - manual page for wp-check-passwords git version
-fba2a66
+8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-check-passwords \[-h\] \[--version\] \[-f FILE\]
+usage: wp-check-passwords \[-h\] \[\--version\] \[-f FILE\]
 
-Scan the wp\_user table for weak passwords. @TODO: Highlight users with
+Scan the wp\_user table for weak passwords. \@TODO: Highlight users with
 admin, editor, writer privileges?
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    show this help message and exit
+**-h**, **\--help**
 
-  - **--version**  
-    show program's version number and exit
+:   show this help message and exit
 
-  - **-f** FILE, **--file** FILE  
-    Tab separated file with a user login, email and password on each
+**\--version**
+
+:   show program\'s version number and exit
+
+**-f** FILE, **\--file** FILE
+
+:   Tab separated file with a user login, email and password on each
     line

--- a/man/wp-check-php-version.md
+++ b/man/wp-check-php-version.md
@@ -3,21 +3,26 @@ title: "wp-check-php-version"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-check-php-version - manual page for wp-check-php-version git version
-fba2a66
+8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
 usage: wp-check-php-version \[options\]
 
 Check PHP version.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    display this help and exit
+**-h**, **\--help**
 
-  - **--version**  
-    display version and exit
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit

--- a/man/wp-check-remote-failure.md
+++ b/man/wp-check-remote-failure.md
@@ -3,28 +3,35 @@ title: "wp-check-remote-failure"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-check-remote-failure - manual page for wp-check-remote-failure git
-version fba2a66
+version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-check-remote-failure \[-h\] \[--version\] \[url\]
+usage: wp-check-remote-failure \[-h\] \[\--version\] \[url\]
 
 Test if WordPress continues to work without remote connections. Block
 connection to remote servers to test if WordPress continues to run as
 expected.
 
-## positional arguments:
+positional arguments:
+---------------------
 
-  - url  
-    URL of page to test
+url
 
-## optional arguments:
+:   URL of page to test
 
-  - **-h**, **--help**  
-    show this help message and exit
+optional arguments:
+-------------------
 
-  - **--version**  
-    show program's version number and exit
+**-h**, **\--help**
+
+:   show this help message and exit
+
+**\--version**
+
+:   show program\'s version number and exit

--- a/man/wp-db-admin.md
+++ b/man/wp-db-admin.md
@@ -3,30 +3,36 @@ title: "wp-db-admin"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-db-admin - manual page for wp-db-admin git version 8ecb3f3
+wp-db-admin - manual page for wp-db-admin git version 8235fae
 
-# SYNOPSIS
+SYNOPSIS
+========
 
 **wp-db-admin**
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
 Access the database proxy admin console.
 
 In the console you can then run queries like:
 
 > SELECT \* FROM stats.stats\_mysql\_connection\_pool;
-> 
+>
 > SELECT digest,SUBSTR(digest\_text,0,50),count\_star,sum\_time FROM
-> stats\_mysql\_query\_digest WHERE digest\_text LIKE 'SELECT%' ORDER BY
-> sum\_time DESC LIMIT 25;
+> stats\_mysql\_query\_digest WHERE digest\_text LIKE \'SELECT%\' ORDER
+> BY sum\_time DESC LIMIT 25;
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    display this help and exit
+**-h**, **\--help**
 
-  - **--version**  
-    display version and exit
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit

--- a/man/wp-db-cleanup.md
+++ b/man/wp-db-cleanup.md
@@ -3,27 +3,34 @@ title: "wp-db-cleanup"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-db-cleanup - manual page for wp-db-cleanup git version fba2a66
+wp-db-cleanup - manual page for wp-db-cleanup git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-db-cleanup \[-h\] \[--version\] \[--delay DELAY\]
-\[--dry-run\]
+usage: wp-db-cleanup \[-h\] \[\--version\] \[\--delay DELAY\]
+\[\--dry-run\]
 
 Safe cleanup of cruft from database.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    show this help message and exit
+**-h**, **\--help**
 
-  - **--version**  
-    show program's version number and exit
+:   show this help message and exit
 
-  - **--delay** DELAY  
-    Safety period in seconds before cleanup
+**\--version**
 
-  - **--dry-run**  
-    Print only how many rows would be deleted in each table
+:   show program\'s version number and exit
+
+**\--delay** DELAY
+
+:   Safety period in seconds before cleanup
+
+**\--dry-run**
+
+:   Print only how many rows would be deleted in each table

--- a/man/wp-db-cli.md
+++ b/man/wp-db-cli.md
@@ -3,25 +3,31 @@ title: "wp-db-cli"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-db-cli - manual page for wp-db-cli git version 8ecb3f3
+wp-db-cli - manual page for wp-db-cli git version 8235fae
 
-# SYNOPSIS
+SYNOPSIS
+========
 
-**wp-db-cli** \[*-h*\] \[*--version*\]
+**wp-db-cli** \[*-h*\] \[*\--version*\]
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
 Quickly access the MariaDB console without having to manually enter
-credentials. Unlike 'wp db cli', this command accesses the database
+credentials. Unlike \'wp db cli\', this command accesses the database
 directly and does not depend on if wp-cli or the site PHP in general
 works or not.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    display this help and exit
+**-h**, **\--help**
 
-  - **--version**  
-    display version and exit
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit

--- a/man/wp-db-dump.md
+++ b/man/wp-db-dump.md
@@ -3,25 +3,32 @@ title: "wp-db-dump"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-db-dump - manual page for wp-db-dump git version fba2a66
+wp-db-dump - manual page for wp-db-dump git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
 usage: wp-db-dump \[options\] \[dumpfile\]
 
 Make a database dump in the standardized Seravo way.
 
-## positional arguments:
+positional arguments:
+---------------------
 
-  - dumpfile  
-    Path to an SQL dump file
+dumpfile
 
-## optional arguments:
+:   Path to an SQL dump file
 
-  - **-h**, **--help**  
-    show this help message and exit
+optional arguments:
+-------------------
 
-  - **--version**  
-    show version and exit
+**-h**, **\--help**
+
+:   show this help message and exit
+
+**\--version**
+
+:   show version and exit

--- a/man/wp-db-info.md
+++ b/man/wp-db-info.md
@@ -3,21 +3,26 @@ title: "wp-db-info"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-db-info - manual page for wp-db-info git version fba2a66
+wp-db-info - manual page for wp-db-info git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
 usage: wp-db-info \[options\]
 
 Show various info about the database contents useful when debugging
 slowness.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    show this help message and exit
+**-h**, **\--help**
 
-  - **--version**  
-    show version and exit
+:   show this help message and exit
+
+**\--version**
+
+:   show version and exit

--- a/man/wp-db-load.md
+++ b/man/wp-db-load.md
@@ -3,29 +3,37 @@ title: "wp-db-load"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-db-load - manual page for wp-db-load git version fba2a66
+wp-db-load - manual page for wp-db-load git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-db-load \[-h\] \[--version\] \[--yes\] \[PATH\]
+usage: wp-db-load \[-h\] \[\--version\] \[\--yes\] \[PATH\]
 
 Load a database dump in the standardized Seravo way
 
-## positional arguments:
+positional arguments:
+---------------------
 
-  - PATH  
-    DB dump (SQL file) to load
+PATH
 
-## optional arguments:
+:   DB dump (SQL file) to load
 
-  - **-h**, **--help**  
-    show this help message and exit
+optional arguments:
+-------------------
 
-  - **--version**  
-    show program's version number and exit
+**-h**, **\--help**
 
-  - **--yes**  
-    Do not ask confirmation. Note: the tool will not ask for
+:   show this help message and exit
+
+**\--version**
+
+:   show program\'s version number and exit
+
+**\--yes**
+
+:   Do not ask confirmation. Note: the tool will not ask for
     confirmation if run from a non-interactive terminal.

--- a/man/wp-db-optimize.md
+++ b/man/wp-db-optimize.md
@@ -3,23 +3,29 @@ title: "wp-db-optimize"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-db-optimize - manual page for wp-db-optimize git version fba2a66
+wp-db-optimize - manual page for wp-db-optimize git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-db-optimize \[-h\] \[--version\] \[--force\]
+usage: wp-db-optimize \[-h\] \[\--version\] \[\--force\]
 
 Optimize databases the correct way.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    show this help message and exit
+**-h**, **\--help**
 
-  - **--version**  
-    show program's version number and exit
+:   show this help message and exit
 
-  - **--force**  
-    Run the optimization despite system load.
+**\--version**
+
+:   show program\'s version number and exit
+
+**\--force**
+
+:   Run the optimization despite system load.

--- a/man/wp-db-size.md
+++ b/man/wp-db-size.md
@@ -3,21 +3,26 @@ title: "wp-db-size"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-db-size - manual page for wp-db-size git version fba2a66
+wp-db-size - manual page for wp-db-size git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
 usage: wp-db-size \[options\]
 
 Just a wrapper for wp-cli so one does not have to remember the command
 arguments.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    show this help message and exit
+**-h**, **\--help**
 
-  - **--version**  
-    show version and exit
+:   show this help message and exit
+
+**\--version**
+
+:   show version and exit

--- a/man/wp-db-update.md
+++ b/man/wp-db-update.md
@@ -3,20 +3,25 @@ title: "wp-db-update"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-db-update - manual page for wp-db-update git version fba2a66
+wp-db-update - manual page for wp-db-update git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
 usage: wp-db-update \[options\]
 
 Update WordPress database to match latest version of WordPress core.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    show this help message and exit
+**-h**, **\--help**
 
-  - **--version**  
-    show version and exit
+:   show this help message and exit
+
+**\--version**
+
+:   show version and exit

--- a/man/wp-development-up.md
+++ b/man/wp-development-up.md
@@ -3,21 +3,26 @@ title: "wp-development-up"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-development-up - manual page for wp-development-up git version
-fba2a66
+8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-development-up \[-h\] \[--version\]
+usage: wp-development-up \[-h\] \[\--version\]
 
 Start Seravo development environment.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    show this help message and exit
+**-h**, **\--help**
 
-  - **--version**  
-    show program's version number and exit
+:   show this help message and exit
+
+**\--version**
+
+:   show program\'s version number and exit

--- a/man/wp-find-code.md
+++ b/man/wp-find-code.md
@@ -3,28 +3,34 @@ title: "wp-find-code"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-find-code - manual page for wp-find-code git version fba2a66
+wp-find-code - manual page for wp-find-code git version 8235fae
 
-# SYNOPSIS
+SYNOPSIS
+========
 
 **wp-find-code** *\<serach term\>*
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
 Search for given string in the PHP files under */data/wordpress*.
 
-This is a simple wrapper for 'grep' with the purpose of saving
-developers the effor of having to manually enter 'grep' arguments.
+This is a simple wrapper for \'grep\' with the purpose of saving
+developers the effor of having to manually enter \'grep\' arguments.
 
-However, if there are extra arguments, they will be passed to 'grep'
+However, if there are extra arguments, they will be passed to \'grep\'
 along with the default ones.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    display this help and exit
+**-h**, **\--help**
 
-  - **--version**  
-    display version and exit
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit

--- a/man/wp-fix-backups.md
+++ b/man/wp-fix-backups.md
@@ -3,18 +3,23 @@ title: "wp-fix-backups"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-fix-backups - manual page for wp-fix-backups git version fba2a66
+wp-fix-backups - manual page for wp-fix-backups git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
 usage: wp-fix-backups \[options\]
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    display this help and exit
+**-h**, **\--help**
 
-  - **--version**  
-    display version and exit
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit

--- a/man/wp-fix-checksums.md
+++ b/man/wp-fix-checksums.md
@@ -3,32 +3,39 @@ title: "wp-fix-checksums"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-fix-checksums - manual page for wp-fix-checksums git version fba2a66
+wp-fix-checksums - manual page for wp-fix-checksums git version 8235fae
 
-# SYNOPSIS
+SYNOPSIS
+========
 
-**wp-fix-checksums** \[*-h*\] \[*--version*\]
+**wp-fix-checksums** \[*-h*\] \[*\--version*\]
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
 Checks the WordPress core installation for modified files, and if any
 are found, automatically re-installs the same WordPress version to
 ensure the core files are unmodified.
 
-Based on 'wp core verify-checksums' with some additional logic. Only 'wp
-core verify-checksum' errors are addressed. Warnings are shown but not
-fixed automatically.
+Based on \'wp core verify-checksums\' with some additional logic. Only
+\'wp core verify-checksum\' errors are addressed. Warnings are shown but
+not fixed automatically.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    display this help and exit
+**-h**, **\--help**
 
-  - **--version**  
-    display version and exit
+:   display this help and exit
 
-# SEE ALSO
+**\--version**
+
+:   display version and exit
+
+SEE ALSO
+========
 
 *wp core*(1)

--- a/man/wp-fix-languages.md
+++ b/man/wp-fix-languages.md
@@ -3,21 +3,26 @@ title: "wp-fix-languages"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-fix-languages - manual page for wp-fix-languages git version fba2a66
+wp-fix-languages - manual page for wp-fix-languages git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
 usage: wp-fix-languages \[options\]
 
 Automates fixing typical situations where language packs are missing or
 not installed.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    display this help and exit
+**-h**, **\--help**
 
-  - **--version**  
-    display version and exit
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit

--- a/man/wp-fix-project.md
+++ b/man/wp-fix-project.md
@@ -3,15 +3,18 @@ title: "wp-fix-project"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-fix-project - manual page for wp-fix-project git version fba2a66
+wp-fix-project - manual page for wp-fix-project git version 8235fae
 
-# SYNOPSIS
+SYNOPSIS
+========
 
-**wp-fix-project** \[*-h*\] \[*--version*\]
+**wp-fix-project** \[*-h*\] \[*\--version*\]
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
 Compares the current WordPress project at */data/wordpress* to the
 upstream Seravo/WordPress project template and attempts to apply all
@@ -21,10 +24,13 @@ as up-to-date as possible.
 For changes that cannot be automatically applied, a diff and/or git
 patch files are provided for easier manual application.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    display this help and exit
+**-h**, **\--help**
 
-  - **--version**  
-    display version and exit
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit

--- a/man/wp-fix-wp-content-symlink.md
+++ b/man/wp-fix-wp-content-symlink.md
@@ -3,16 +3,19 @@ title: "wp-fix-wp-content-symlink"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-fix-wp-content-symlink - manual page for wp-fix-wp-content-symlink
-git version fba2a66
+git version 8235fae
 
-# SYNOPSIS
+SYNOPSIS
+========
 
-**wp-fix-wp-content-symlink** \[*-h*\] \[*--version*\] \[*--force*\]
+**wp-fix-wp-content-symlink** \[*-h*\] \[*\--version*\] \[*\--force*\]
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
 Check that a correct wordpress/wp-content -\> ../wp-content symlink is
 found so that the WordPress installation would work correctly.
@@ -20,14 +23,18 @@ found so that the WordPress installation would work correctly.
 If not found, tries to fix the WordPress installation and create the
 symlink correctly.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **--force**  
-    force wp-content symlink fix, useful if the fix could not otherwise
+**\--force**
+
+:   force wp-content symlink fix, useful if the fix could not otherwise
     be applied automatically
 
-  - **-h**, **--help**  
-    display this help and exit
+**-h**, **\--help**
 
-  - **--version**  
-    display version and exit
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit

--- a/man/wp-generate-ssl.md
+++ b/man/wp-generate-ssl.md
@@ -3,20 +3,25 @@ title: "wp-generate-ssl"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-generate-ssl - manual page for wp-generate-ssl git version fba2a66
+wp-generate-ssl - manual page for wp-generate-ssl git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-generate-ssl \[-h\] \[--version\]
+usage: wp-generate-ssl \[-h\] \[\--version\]
 
 Generate SSL-certificate for all domains in config.yml.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    show this help message and exit
+**-h**, **\--help**
 
-  - **--version**  
-    show program's version number and exit
+:   show this help message and exit
+
+**\--version**
+
+:   show program\'s version number and exit

--- a/man/wp-git-status.md
+++ b/man/wp-git-status.md
@@ -3,23 +3,29 @@ title: "wp-git-status"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-git-status - manual page for wp-git-status git version fba2a66
+wp-git-status - manual page for wp-git-status git version 8235fae
 
-# SYNOPSIS
+SYNOPSIS
+========
 
-**wp-git-status** \[*-h*\] \[*--version*\]
+**wp-git-status** \[*-h*\] \[*\--version*\]
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
 Show a quick summary of state of the files in */data/wordpress*, based
 on git status.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    display this help and exit
+**-h**, **\--help**
 
-  - **--version**  
-    display version and exit
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit

--- a/man/wp-last-ssh-logins.md
+++ b/man/wp-last-ssh-logins.md
@@ -3,26 +3,32 @@ title: "wp-last-ssh-logins"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-last-ssh-logins - manual page for wp-last-ssh-logins git version
-fba2a66
+8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-last-ssh-logins \[-h\] \[--version\] \[--user USER\]
+usage: wp-last-ssh-logins \[-h\] \[\--version\] \[\--user USER\]
 
 List latest ssh login attempts. List last logins according to system
 status history and failed logins based on wtmp and btmp.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    show this help message and exit
+**-h**, **\--help**
 
-  - **--version**  
-    show program's version number and exit
+:   show this help message and exit
 
-  - **--user** USER  
-    Analyze SSH publickey logins of given user. If not given, analyze
+**\--version**
+
+:   show program\'s version number and exit
+
+**\--user** USER
+
+:   Analyze SSH publickey logins of given user. If not given, analyze
     the default WP user.

--- a/man/wp-last-wp-logins-ng.md
+++ b/man/wp-last-wp-logins-ng.md
@@ -3,30 +3,38 @@ title: "wp-last-wp-logins-ng"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-last-wp-logins-ng - manual page for wp-last-wp-logins-ng git version
-fba2a66
+8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-last-wp-logins-ng \[-h\] \[--version\]
+usage: wp-last-wp-logins-ng \[-h\] \[\--version\]
 
-  - \[--max-unsuccessful MAX\_UNSUCCESSFUL\]  
-    \[--max-days MAX\_DAYS\]
+\[\--max-unsuccessful MAX\_UNSUCCESSFUL\]
 
-'List last logins based on */data/log/wp-login*.log\*.
+:   \[\--max-days MAX\_DAYS\]
 
-## optional arguments:
+\'List last logins based on */data/log/wp-login*.log\*.
 
-  - **-h**, **--help**  
-    show this help message and exit
+optional arguments:
+-------------------
 
-  - **--version**  
-    show program's version number and exit
+**-h**, **\--help**
 
-  - **--max-unsuccessful** MAX\_UNSUCCESSFUL  
-    Display at maximum given many unsuccessful logins
+:   show this help message and exit
 
-  - **--max-days** MAX\_DAYS  
-    Read at least given many days logs
+**\--version**
+
+:   show program\'s version number and exit
+
+**\--max-unsuccessful** MAX\_UNSUCCESSFUL
+
+:   Display at maximum given many unsuccessful logins
+
+**\--max-days** MAX\_DAYS
+
+:   Read at least given many days logs

--- a/man/wp-last-wp-logins.md
+++ b/man/wp-last-wp-logins.md
@@ -3,30 +3,26 @@ title: "wp-last-wp-logins"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-last-wp-logins - manual page for wp-last-wp-logins git version
-8ecb3f3
+8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-last-wp-logins \[-h\] \[--version\]
+usage: wp-last-wp-logins \[options\]
 
-  - \[--max-unsuccessful MAX\_UNSUCCESSFUL\]  
-    \[--max-days MAX\_DAYS\]
+List last logins based on wp-login.log
 
-'List last logins based on */data/log/wp-login*.log\*.
+optional arguments:
+-------------------
 
-## optional arguments:
+**-h**, **\--help**
 
-  - **-h**, **--help**  
-    show this help message and exit
+:   display this help and exit
 
-  - **--version**  
-    show program's version number and exit
+**\--version**
 
-  - **--max-unsuccessful** MAX\_UNSUCCESSFUL  
-    Display at maximum given many unsuccessful logins
-
-  - **--max-days** MAX\_DAYS  
-    Read at least given many days logs
+:   display version and exit

--- a/man/wp-list-env.md
+++ b/man/wp-list-env.md
@@ -3,23 +3,29 @@ title: "wp-list-env"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-list-env - manual page for wp-list-env git version fba2a66
+wp-list-env - manual page for wp-list-env git version 8235fae
 
-# SYNOPSIS
+SYNOPSIS
+========
 
-**wp-list-env** \[*-h*\] \[*--version*\]
+**wp-list-env** \[*-h*\] \[*\--version*\]
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
 List environment variables that affect the WordPress installation at
 */data/wordpress*
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    display this help and exit
+**-h**, **\--help**
 
-  - **--version**  
-    display version and exit
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit

--- a/man/wp-list-files-ctime.md
+++ b/man/wp-list-files-ctime.md
@@ -3,12 +3,14 @@ title: "wp-list-files-ctime"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-list-files-ctime - manual page for wp-list-files-ctime git version
-fba2a66
+8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
 usage: wp-list-files-ctime \[options\]
 
@@ -16,18 +18,23 @@ List all recently changed filed based on ctime. This is less reliable
 then wp-backup-list-changes as files can have their ctime attribute set
 to anything.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-c**  
-    code investigation **-mode**, ignore image and binary translation
+**-c**
+
+:   code investigation **-mode**, ignore image and binary translation
     files
 
-  - **-h**, **--help**  
-    display this help and exit
+**-h**, **\--help**
 
-  - **--version**  
-    display version and exit
+:   display this help and exit
 
-# SEE ALSO
+**\--version**
+
+:   display version and exit
+
+SEE ALSO
+========
 
 *wp-backup-list-changes*(1)

--- a/man/wp-list-files-mtime.md
+++ b/man/wp-list-files-mtime.md
@@ -3,12 +3,14 @@ title: "wp-list-files-mtime"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-list-files-mtime - manual page for wp-list-files-mtime git version
-fba2a66
+8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
 usage: wp-list-files-mtime \[options\]
 
@@ -16,18 +18,23 @@ List all recently changed filed based on mtime. This is less reliable
 then wp-backup-list-changes as files can have their mtime attribute set
 to anything.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-c**  
-    code investigation **-mode**, ignore image and binary translation
+**-c**
+
+:   code investigation **-mode**, ignore image and binary translation
     files
 
-  - **-h**, **--help**  
-    display this help and exit
+**-h**, **\--help**
 
-  - **--version**  
-    display version and exit
+:   display this help and exit
 
-# SEE ALSO
+**\--version**
+
+:   display version and exit
+
+SEE ALSO
+========
 
 *wp-backup-list-changes*(1)

--- a/man/wp-load-test-ng.md
+++ b/man/wp-load-test-ng.md
@@ -3,83 +3,105 @@ title: "wp-load-test-ng"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-load-test-ng - manual page for wp-load-test-ng git version fba2a66
+wp-load-test-ng - manual page for wp-load-test-ng git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-load-test-ng \[-h\] \[--version\] \[--cache\] \[--initial-qps
-INITIAL\_QPS\]
+usage: wp-load-test-ng \[-h\] \[\--version\] \[\--cache\]
+\[\--initial-qps INITIAL\_QPS\]
 
-  - \[--interval INTERVAL\]  
-    \[--latency \[LATENCIES \[LATENCIES ...\]\]\] \[--max-logs
-    MAX\_LOGS\] \[--max-qps MAX\_QPS\] \[--use-nginx-logs\] \[--num-bots
-    NUM\_BOTS\] \[--num-intervals NUM\_INTERVALS\]
-    \[--num-failed-intervals NUM\_FAILED\_INTERVALS\] \[--qps-add
-    QPS\_ADD\] \[--safe-time SAFE\_TIME\] \[--url-file URL\_FILE\] \[url
-    \[url ...\]\]
+\[\--interval INTERVAL\]
+
+:   \[\--latency \[LATENCIES \[LATENCIES \...\]\]\] \[\--max-logs
+    MAX\_LOGS\] \[\--max-qps MAX\_QPS\] \[\--use-nginx-logs\]
+    \[\--num-bots NUM\_BOTS\] \[\--num-intervals NUM\_INTERVALS\]
+    \[\--num-failed-intervals NUM\_FAILED\_INTERVALS\] \[\--qps-add
+    QPS\_ADD\] \[\--safe-time SAFE\_TIME\] \[\--url-file URL\_FILE\]
+    \[url \[url \...\]\]
 
 Simple loadtesting tool for WordPress sites.
 
-## positional arguments:
+positional arguments:
+---------------------
 
-  - url  
-    Site URL to the target site.
+url
 
-## optional arguments:
+:   Site URL to the target site.
 
-  - **-h**, **--help**  
-    show this help message and exit
+optional arguments:
+-------------------
 
-  - **--version**  
-    show program's version number and exit
+**-h**, **\--help**
 
-  - **--cache**  
-    If **--cache** is not used, "Pragma: no-cache" header is set.
+:   show this help message and exit
 
-  - **--initial-qps** INITIAL\_QPS  
-    Initial total QPS from all load bots.
+**\--version**
 
-  - **--interval** INTERVAL  
-    Duration of a round.
+:   show program\'s version number and exit
 
-  - **--latency** \[LATENCIES \[LATENCIES ...\]\]  
-    Set latency requirement **--latency**=*percentile*,max\_latency
+**\--cache**
+
+:   If **\--cache** is not used, \"Pragma: no-cache\" header is set.
+
+**\--initial-qps** INITIAL\_QPS
+
+:   Initial total QPS from all load bots.
+
+**\--interval** INTERVAL
+
+:   Duration of a round.
+
+**\--latency** \[LATENCIES \[LATENCIES \...\]\]
+
+:   Set latency requirement **\--latency**=*percentile*,max\_latency
     where percentile is a float in range \[0, 100\] and max\_latency is
-    a positive value in seconds (float). Example: **--latency**=*99*,2.5
-    means that the 99th percentile latency should be less than 2.5s.
-    percentile == 100 means maximum latency. This option can be used
-    many times to specify multiple latency requirements. E.g.
-    simultaneously set both median and maximum latency.
+    a positive value in seconds (float). Example:
+    **\--latency**=*99*,2.5 means that the 99th percentile latency
+    should be less than 2.5s. percentile == 100 means maximum latency.
+    This option can be used many times to specify multiple latency
+    requirements. E.g. simultaneously set both median and maximum
+    latency.
 
-  - **--max-logs** MAX\_LOGS  
-    Maximum number of URLs to replay. Zero means no limit.
+**\--max-logs** MAX\_LOGS
 
-  - **--max-qps** MAX\_QPS  
-    Total maximum QPS from all load bots.
+:   Maximum number of URLs to replay. Zero means no limit.
 
-  - **--use-nginx-logs**  
-    Use nginx logs for load test. Read all HTTP GET requests with status
+**\--max-qps** MAX\_QPS
+
+:   Total maximum QPS from all load bots.
+
+**\--use-nginx-logs**
+
+:   Use nginx logs for load test. Read all HTTP GET requests with status
     code 200.
 
-  - **--num-bots** NUM\_BOTS  
-    Set the number of load bots sending traffic to the target site
+**\--num-bots** NUM\_BOTS
 
-  - **--num-intervals** NUM\_INTERVALS  
-    Send constant QPS for given amount of intervals (each interval with
-    duration given by **--interval**) before ramping up QPS.
+:   Set the number of load bots sending traffic to the target site
 
-  - **--num-failed-intervals** NUM\_FAILED\_INTERVALS  
-    Report failure if load test criteria are not met in given many
+**\--num-intervals** NUM\_INTERVALS
+
+:   Send constant QPS for given amount of intervals (each interval with
+    duration given by **\--interval**) before ramping up QPS.
+
+**\--num-failed-intervals** NUM\_FAILED\_INTERVALS
+
+:   Report failure if load test criteria are not met in given many
     consecutive intervals.
 
-  - **--qps-add** QPS\_ADD  
-    Increase load in steps of given QPS.
+**\--qps-add** QPS\_ADD
 
-  - **--safe-time** SAFE\_TIME  
-    Wait given many seconds before starting the load test.
+:   Increase load in steps of given QPS.
 
-  - **--url-file** URL\_FILE  
-    Path to file containing one URL per line. Empty lines and lines
+**\--safe-time** SAFE\_TIME
+
+:   Wait given many seconds before starting the load test.
+
+**\--url-file** URL\_FILE
+
+:   Path to file containing one URL per line. Empty lines and lines
     beginning with \# are ignored.

--- a/man/wp-load-test.md
+++ b/man/wp-load-test.md
@@ -3,13 +3,15 @@ title: "wp-load-test"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-load-test - manual page for wp-load-test git version fba2a66
+wp-load-test - manual page for wp-load-test git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-load-test \[--cache\] \[-h\] \[--version\] \[URL\]
+usage: wp-load-test \[\--cache\] \[-h\] \[\--version\] \[URL\]
 
 wp-load-test is a simple command line tool to measure many consecutive
 PHP requests the site can handle in a minute while still serving each
@@ -23,13 +25,17 @@ yield 429 responses.
 
 Defaults to using output of wp-url if URL argument is not given.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **--cache**  
-    Measures cached results. This does not measure actual PHP speed.
+**\--cache**
 
-  - **-h**, **--help**  
-    display this help and exit
+:   Measures cached results. This does not measure actual PHP speed.
 
-  - **--version**  
-    display version and exit
+**-h**, **\--help**
+
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit

--- a/man/wp-mail-test.md
+++ b/man/wp-mail-test.md
@@ -3,21 +3,26 @@ title: "wp-mail-test"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-mail-test - manual page for wp-mail-test git version fba2a66
+wp-mail-test - manual page for wp-mail-test git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-mail-test \[-h\] \[--version\] to \[from\]
+usage: wp-mail-test \[-h\] \[\--version\] to \[from\]
 
 A simple command line tool to test that mail() works as expected.
 Combine with mail-tester.com for most comprehensive results.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    display this help and exit
+**-h**, **\--help**
 
-  - **--version**  
-    display version and exit
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit

--- a/man/wp-makepot.md
+++ b/man/wp-makepot.md
@@ -3,18 +3,23 @@ title: "wp-makepot"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-makepot - manual page for wp-makepot git version fba2a66
+wp-makepot - manual page for wp-makepot git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
 usage: wp-makepot \[options\]
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    display this help and exit
+**-h**, **\--help**
 
-  - **--version**  
-    display version and exit
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit

--- a/man/wp-network-status.md
+++ b/man/wp-network-status.md
@@ -3,21 +3,26 @@ title: "wp-network-status"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-network-status - manual page for wp-network-status git version
-fba2a66
+8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
 usage: wp-network-status \[options\]
 
 List status of WordPress Network.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    display this help and exit
+**-h**, **\--help**
 
-  - **--version**  
-    display version and exit
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit

--- a/man/wp-optimize-images.md
+++ b/man/wp-optimize-images.md
@@ -3,18 +3,21 @@ title: "wp-optimize-images"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-optimize-images - manual page for wp-optimize-images git version
-fba2a66
+8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-optimize-images \[-h\] \[--version\] \[--enable\]
+usage: wp-optimize-images \[-h\] \[\--version\] \[\--enable\]
 
-  - \[--set-max-resolution-width MAX\_RESOLUTION\_WIDTH\]  
-    \[--set-max-resolution-height MAX\_RESOLUTION\_HEIGHT\] \[-f\]
-    \[--strip-metadata\] \[path\]
+\[\--set-max-resolution-width MAX\_RESOLUTION\_WIDTH\]
+
+:   \[\--set-max-resolution-height MAX\_RESOLUTION\_HEIGHT\] \[-f\]
+    \[\--strip-metadata\] \[path\]
 
 Optimize images on a WordPress site. Can be given a path, scans
 \*/data/wordpress/htdocs/wp-content/uploads/\* as default. Runs only if
@@ -24,35 +27,46 @@ width and height saved in the datadase. Maximum image quality for JPEG
 is set to 90. Image quality for PNG files is set to 7. Prints the output
 to terminal and */data/log/wpoptimize-images.log*
 
-## positional arguments:
+positional arguments:
+---------------------
 
-  - path  
-    File or directory of images to optimize
+path
 
-## optional arguments:
+:   File or directory of images to optimize
 
-  - **-h**, **--help**  
-    show this help message and exit
+optional arguments:
+-------------------
 
-  - **--version**  
-    show program's version number and exit
+**-h**, **\--help**
 
-  - **--enable**  
-    Enable image optimization even if seravo-enableoptimize-images is
-    not "on"
+:   show this help message and exit
 
-  - **--set-max-resolution-width** MAX\_RESOLUTION\_WIDTH  
-    Set to override seravo-image-max-resolution-width.
+**\--version**
 
-  - **--set-max-resolution-height** MAX\_RESOLUTION\_HEIGHT  
-    Set to override seravo-image-max-resolution-height.
+:   show program\'s version number and exit
 
-  - **-f**, **--force**  
-    Force optimization.
+**\--enable**
 
-  - **--strip-metadata**  
-    Remove metadata from images
+:   Enable image optimization even if seravo-enableoptimize-images is
+    not \"on\"
 
-# SEE ALSO
+**\--set-max-resolution-width** MAX\_RESOLUTION\_WIDTH
+
+:   Set to override seravo-image-max-resolution-width.
+
+**\--set-max-resolution-height** MAX\_RESOLUTION\_HEIGHT
+
+:   Set to override seravo-image-max-resolution-height.
+
+**-f**, **\--force**
+
+:   Force optimization.
+
+**\--strip-metadata**
+
+:   Remove metadata from images
+
+SEE ALSO
+========
 
 *jpegoptim*(1), *optipng*(1)

--- a/man/wp-php-compatibility-check.md
+++ b/man/wp-php-compatibility-check.md
@@ -1,0 +1,44 @@
+---
+title: "wp-php-compatibility-check"
+---
+
+
+NAME
+====
+
+wp-php-compatibility-check - manual page for wp-php-compatibility-check
+git version 8235fae
+
+DESCRIPTION
+===========
+
+usage: wp-php-compatibility-check \[-h\] \[\--version\] \[path
+\[phpversion\]\]
+
+Check that the PHP code of the current WordPress installation, including
+themes and plugins, is compatible with the PHP specified.
+
+This is based on phpcs and it\'s PHP compatibility rulesets.
+
+positional arguments:
+---------------------
+
+path
+
+:   Path to site. Defaults to
+    */data/wordpress/htdocs/wordpress/wp-content*
+
+phpversion
+
+:   PHP version. Defaults to 7.4.
+
+optional arguments:
+-------------------
+
+**-h**, **\--help**
+
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit

--- a/man/wp-php-slowlog.md
+++ b/man/wp-php-slowlog.md
@@ -3,27 +3,34 @@ title: "wp-php-slowlog"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-php-slowlog - manual page for wp-php-slowlog git version fba2a66
+wp-php-slowlog - manual page for wp-php-slowlog git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-php-slowlog \[-e\] \[-d\] \[-h\] \[--version\]
+usage: wp-php-slowlog \[-e\] \[-d\] \[-h\] \[\--version\]
 
 Enable/disable logging for long-running PHP requests. When enabled, will
 log slow PHP runs for 3 hours.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-e**, **--enable**  
-    enable PHP slowlog
+**-e**, **\--enable**
 
-  - **-d**, **--disable**  
-    disable PHP slowlog
+:   enable PHP slowlog
 
-  - **-h**, **--help**  
-    display this help and exit
+**-d**, **\--disable**
 
-  - **--version**  
-    display version and exit
+:   disable PHP slowlog
+
+**-h**, **\--help**
+
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit

--- a/man/wp-pomo-compile.md
+++ b/man/wp-pomo-compile.md
@@ -3,29 +3,37 @@ title: "wp-pomo-compile"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-pomo-compile - manual page for wp-pomo-compile git version fba2a66
+wp-pomo-compile - manual page for wp-pomo-compile git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-pomo-compile \[-h\] \[--version\] \[path\]
+usage: wp-pomo-compile \[-h\] \[\--version\] \[path\]
 
 Compile clear text PO translation files into binary MO files.
 
-## positional arguments:
+positional arguments:
+---------------------
 
-  - path  
-    Path to wp-content. Defaults to */data/wordpress/htdocs/wp-content*.
+path
 
-## optional arguments:
+:   Path to wp-content. Defaults to */data/wordpress/htdocs/wp-content*.
 
-  - **-h**, **--help**  
-    display this help and exit
+optional arguments:
+-------------------
 
-  - **--version**  
-    display version and exit
+**-h**, **\--help**
 
-# SEE ALSO
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit
+
+SEE ALSO
+========
 
 *msgfmt*(1), *wp-makepot*(1), *wp i18n*(1)

--- a/man/wp-pull-production-core.md
+++ b/man/wp-pull-production-core.md
@@ -3,21 +3,26 @@ title: "wp-pull-production-core"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-pull-production-core - manual page for wp-pull-production-core git
-version fba2a66
+version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-pull-production-core \[-h\] \[--version\]
+usage: wp-pull-production-core \[-h\] \[\--version\]
 
 Install the same WordPress core version as on production site.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    show this help message and exit
+**-h**, **\--help**
 
-  - **--version**  
-    show program's version number and exit
+:   show this help message and exit
+
+**\--version**
+
+:   show program\'s version number and exit

--- a/man/wp-pull-production-db.md
+++ b/man/wp-pull-production-db.md
@@ -3,21 +3,26 @@ title: "wp-pull-production-db"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-pull-production-db - manual page for wp-pull-production-db git
-version fba2a66
+version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-pull-production-db \[-h\] \[--version\]
+usage: wp-pull-production-db \[-h\] \[\--version\]
 
 Pull database from production site.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    show this help message and exit
+**-h**, **\--help**
 
-  - **--version**  
-    show program's version number and exit
+:   show this help message and exit
+
+**\--version**
+
+:   show program\'s version number and exit

--- a/man/wp-pull-production-plugins.md
+++ b/man/wp-pull-production-plugins.md
@@ -3,21 +3,26 @@ title: "wp-pull-production-plugins"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-pull-production-plugins - manual page for wp-pull-production-plugins
-git version fba2a66
+git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-pull-production-plugins \[-h\] \[--version\]
+usage: wp-pull-production-plugins \[-h\] \[\--version\]
 
 Pull plugins from production site.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    show this help message and exit
+**-h**, **\--help**
 
-  - **--version**  
-    show program's version number and exit
+:   show this help message and exit
+
+**\--version**
+
+:   show program\'s version number and exit

--- a/man/wp-pull-production-themes.md
+++ b/man/wp-pull-production-themes.md
@@ -3,21 +3,26 @@ title: "wp-pull-production-themes"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-pull-production-themes - manual page for wp-pull-production-themes
-git version fba2a66
+git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-pull-production-themes \[-h\] \[--version\]
+usage: wp-pull-production-themes \[-h\] \[\--version\]
 
 Pull themes from production site.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    show this help message and exit
+**-h**, **\--help**
 
-  - **--version**  
-    show program's version number and exit
+:   show this help message and exit
+
+**\--version**
+
+:   show program\'s version number and exit

--- a/man/wp-pull-staging-db.md
+++ b/man/wp-pull-staging-db.md
@@ -3,21 +3,26 @@ title: "wp-pull-staging-db"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-pull-staging-db - manual page for wp-pull-staging-db git version
-fba2a66
+8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-pull-staging-db \[-h\] \[--version\]
+usage: wp-pull-staging-db \[-h\] \[\--version\]
 
 Pull database from shadow site.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    show this help message and exit
+**-h**, **\--help**
 
-  - **--version**  
-    show program's version number and exit
+:   show this help message and exit
+
+**\--version**
+
+:   show program\'s version number and exit

--- a/man/wp-purge-cache.md
+++ b/man/wp-purge-cache.md
@@ -3,11 +3,13 @@ title: "wp-purge-cache"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-purge-cache - manual page for wp-purge-cache git version fba2a66
+wp-purge-cache - manual page for wp-purge-cache git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
 usage: wp-purge-cache \[options\]
 
@@ -17,14 +19,18 @@ and PageSpeed cache. Restart nginx.
 Note: wp-purge-cache does nothing in a development environment. It is
 only effective in production/staging (shadow).
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    display this help and exit
+**-h**, **\--help**
 
-  - **--version**  
-    display version and exit
+:   display this help and exit
 
-# SEE ALSO
+**\--version**
+
+:   display version and exit
+
+SEE ALSO
+========
 
 *wp-flush-cache*(1)

--- a/man/wp-reload-nginx.md
+++ b/man/wp-reload-nginx.md
@@ -3,13 +3,15 @@ title: "wp-reload-nginx"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-reload-nginx - manual page for wp-reload-nginx git version fba2a66
+wp-reload-nginx - manual page for wp-reload-nginx git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-reload-nginx \[-h\] \[--version\]
+usage: wp-reload-nginx \[-h\] \[\--version\]
 
 Reload Nginx configuration. If the configuration is invalid, the script
 returns with error and Nginx continues with the old (valid) config.
@@ -17,14 +19,18 @@ returns with error and Nginx continues with the old (valid) config.
 Note: User specific Nginx configuration is located at
 /data/wordpress/nginx/\*.conf.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    display this help and exit
+**-h**, **\--help**
 
-  - **--version**  
-    display version and exit
+:   display this help and exit
 
-# SEE ALSO
+**\--version**
+
+:   display version and exit
+
+SEE ALSO
+========
 
 *wp-restart-nginx*(1)

--- a/man/wp-remote-db-on.md
+++ b/man/wp-remote-db-on.md
@@ -3,23 +3,28 @@ title: "wp-remote-db-on"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-remote-db-on - manual page for wp-remote-db-on git version fba2a66
+wp-remote-db-on - manual page for wp-remote-db-on git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-remote-db-on \[-h\] \[--version\]
+usage: wp-remote-db-on \[-h\] \[\--version\]
 
 Enable Vagrant MariaDB server to accept connections from developer
 tools. This is a potential security issue. A malicious attacker on your
 local network who knows the database credentials might gain remote
 access.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    display this help and exit
+**-h**, **\--help**
 
-  - **--version**  
-    display version and exit
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit

--- a/man/wp-reset-all-passwords.md
+++ b/man/wp-reset-all-passwords.md
@@ -3,37 +3,45 @@ title: "wp-reset-all-passwords"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-reset-all-passwords - manual page for wp-reset-all-passwords git
-version fba2a66
+version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-reset-all-passwords \[-h\] \[--version\] \[--force\] \[--roles
-ROLES\]
+usage: wp-reset-all-passwords \[-h\] \[\--version\] \[\--force\]
+\[\--roles ROLES\]
 
-> \[--send-email\]
+> \[\--send-email\]
 
 Reset passwords of all users. Reset passwords for all WordPress users.
 Users are sent an automatic password reset notification email if
-**--send-email** is used.
+**\--send-email** is used.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    show this help message and exit
+**-h**, **\--help**
 
-  - **--version**  
-    show program's version number and exit
+:   show this help message and exit
 
-  - **--force**, **--yes**  
-    Do not ask for confirmation
+**\--version**
 
-  - **--roles** ROLES  
-    Reset passwords for all users that match the given comma separated
-    list of roles. Reset passwords for all users if 'all' is given. This
-    is the default.
+:   show program\'s version number and exit
 
-  - **--send-email**  
-    Send email to each user whose password is reset
+**\--force**, **\--yes**
+
+:   Do not ask for confirmation
+
+**\--roles** ROLES
+
+:   Reset passwords for all users that match the given comma separated
+    list of roles. Reset passwords for all users if \'all\' is given.
+    This is the default.
+
+**\--send-email**
+
+:   Send email to each user whose password is reset

--- a/man/wp-reset-all-sessions.md
+++ b/man/wp-reset-all-sessions.md
@@ -3,21 +3,26 @@ title: "wp-reset-all-sessions"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-reset-all-sessions - manual page for wp-reset-all-sessions git
-version fba2a66
+version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-reset-all-sessions \[-h\] \[--version\]
+usage: wp-reset-all-sessions \[-h\] \[\--version\]
 
 Reset all sessions for all WordPress users.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    show this help message and exit
+**-h**, **\--help**
 
-  - **--version**  
-    show program's version number and exit
+:   show this help message and exit
+
+**\--version**
+
+:   show program\'s version number and exit

--- a/man/wp-reset-ssh-password.md
+++ b/man/wp-reset-ssh-password.md
@@ -3,21 +3,26 @@ title: "wp-reset-ssh-password"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-reset-ssh-password - manual page for wp-reset-ssh-password git
-version fba2a66
+version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-reset-ssh-password \[-h\] \[--version\]
+usage: wp-reset-ssh-password \[-h\] \[\--version\]
 
 Reset all ssh passwords.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    show this help message and exit
+**-h**, **\--help**
 
-  - **--version**  
-    show program's version number and exit
+:   show this help message and exit
+
+**\--version**
+
+:   show program\'s version number and exit

--- a/man/wp-restart-db.md
+++ b/man/wp-restart-db.md
@@ -3,22 +3,27 @@ title: "wp-restart-db"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-restart-db - manual page for wp-restart-db git version fba2a66
+wp-restart-db - manual page for wp-restart-db git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-restart-db \[-h\] \[--version\]
+usage: wp-restart-db \[-h\] \[\--version\]
 
 Restart connections to the database. Any connections that are taking too
 long or are stuck will be stopped during the restarting of database
 connections.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    show this help message and exit
+**-h**, **\--help**
 
-  - **--version**  
-    show program's version number and exit
+:   show this help message and exit
+
+**\--version**
+
+:   show program\'s version number and exit

--- a/man/wp-restart-nginx.md
+++ b/man/wp-restart-nginx.md
@@ -3,16 +3,18 @@ title: "wp-restart-nginx"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-restart-nginx - manual page for wp-restart-nginx git version fba2a66
+wp-restart-nginx - manual page for wp-restart-nginx git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-restart-nginx \[-h\] \[--quiet\] \[--version\]
+usage: wp-restart-nginx \[-h\] \[\--quiet\] \[\--version\]
 
 Restart Nginx. The tool first shows what would change in the new
-configuration unless **--quiet** is given. Then it validates the
+configuration unless **\--quiet** is given. Then it validates the
 configuration. If the configuration is invalid, the tool returns with
 error. If configuration is valid, PHP is restarted with wp-php-restart.
 Then Nginx is restarted, briefly interrupting the service (i.e. clients
@@ -21,17 +23,22 @@ can experience errors).
 Note: User specific Nginx configuration is located at
 /data/wordpress/nginx/\*.conf.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **--quiet**  
-    do not display configuration changes
+**\--quiet**
 
-  - **-h**, **--help**  
-    display this help and exit
+:   do not display configuration changes
 
-  - **--version**  
-    display version and exit
+**-h**, **\--help**
 
-# SEE ALSO
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit
+
+SEE ALSO
+========
 
 *wp-reload-nginx*(1), *wp-restart-php*(1)

--- a/man/wp-restart-php.md
+++ b/man/wp-restart-php.md
@@ -3,24 +3,30 @@ title: "wp-restart-php"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-restart-php - manual page for wp-restart-php git version fba2a66
+wp-restart-php - manual page for wp-restart-php git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-restart-php \[-h\] \[--quiet\] \[--version\]
+usage: wp-restart-php \[-h\] \[\--quiet\] \[\--version\]
 
 Restart all PHP processes. Any PHP running that is stuck, will be thus
 down.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **--quiet**  
-    Do not show config changes
+**\--quiet**
 
-  - **-h**, **--help**  
-    display this help and exit
+:   Do not show config changes
 
-  - **--version**  
-    display version and exit
+**-h**, **\--help**
+
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit

--- a/man/wp-seravo-plugin-update.md
+++ b/man/wp-seravo-plugin-update.md
@@ -3,28 +3,35 @@ title: "wp-seravo-plugin-update"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-seravo-plugin-update - manual page for wp-seravo-plugin-update git
-version 8ecb3f3
+version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-seravo-plugin-update \[-h\] \[--version\] \[--dev\]
-\[--reinstall\]
+usage: wp-seravo-plugin-update \[-h\] \[\--version\] \[\--dev\]
+\[\--reinstall\]
 
 Update the must-use seravo-plugin to the latest version.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    show this help message and exit
+**-h**, **\--help**
 
-  - **--version**  
-    show program's version number and exit
+:   show this help message and exit
 
-  - **--dev**  
-    Install the latest Git version
+**\--version**
 
-  - **--reinstall**  
-    Reinstall the plugin even if the latest version is already installed
+:   show program\'s version number and exit
+
+**\--dev**
+
+:   Install the latest Git version
+
+**\--reinstall**
+
+:   Reinstall the plugin even if the latest version is already installed

--- a/man/wp-shadow-pull.md
+++ b/man/wp-shadow-pull.md
@@ -3,16 +3,18 @@ title: "wp-shadow-pull"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-shadow-pull - manual page for wp-shadow-pull git version 8ecb3f3
+wp-shadow-pull - manual page for wp-shadow-pull git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-shadow-pull \[-h\] \[--version\] \[--force\]
+usage: wp-shadow-pull \[-h\] \[\--version\] \[\--force\]
 \[shadow\_to\_pull\]
 
-Move data from a shadow instance to production. Given a shadow the tool
+Move data from production to shadow instances. Given a shadow the tool
 will overwrite almost all of the files located in the path
 /data/wordpress/ on your production site. You may choose to import the
 database from the shadow when given a user prompt. Before executing the
@@ -23,22 +25,29 @@ confident that you really want to replace the current files in
 production with files from the shadow environment. Lists all available
 shadows when called with no arguments.
 
-## positional arguments:
+positional arguments:
+---------------------
 
-  - shadow\_to\_pull  
-    Name of the shadow to pull
+shadow\_to\_pull
 
-## optional arguments:
+:   Name of the shadow to pull
 
-  - **-h**, **--help**  
-    show this help message and exit
+optional arguments:
+-------------------
 
-  - **--version**  
-    show program's version number and exit
+**-h**, **\--help**
 
-  - **--force**  
-    Skip all user prompts, convenient for script usage
+:   show this help message and exit
 
-# SEE ALSO
+**\--version**
+
+:   show program\'s version number and exit
+
+**\--force**
+
+:   Skip all user prompts, convenient for script usage
+
+SEE ALSO
+========
 
 *wp-shadow-reset*(1), *wp-backup*(1)

--- a/man/wp-shadow-reset.md
+++ b/man/wp-shadow-reset.md
@@ -3,35 +3,44 @@ title: "wp-shadow-reset"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-shadow-reset - manual page for wp-shadow-reset git version fba2a66
+wp-shadow-reset - manual page for wp-shadow-reset git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-shadow-reset \[-h\] \[--version\] \[--force\]
+usage: wp-shadow-reset \[-h\] \[\--version\] \[\--force\]
 \[shadow\_to\_reset\]
 
 Move data from production to shadow instances. Delete and replace all
 files in the /data/wordpress/ directory of a shadow with a clone from
 production.
 
-## positional arguments:
+positional arguments:
+---------------------
 
-  - shadow\_to\_reset  
-    Name of the shadow to reset
+shadow\_to\_reset
 
-## optional arguments:
+:   Name of the shadow to reset
 
-  - **-h**, **--help**  
-    show this help message and exit
+optional arguments:
+-------------------
 
-  - **--version**  
-    show program's version number and exit
+**-h**, **\--help**
 
-  - **--force**  
-    Skip user prompt
+:   show this help message and exit
 
-# SEE ALSO
+**\--version**
+
+:   show program\'s version number and exit
+
+**\--force**
+
+:   Skip user prompt
+
+SEE ALSO
+========
 
 *wp-shadow-pull*(1), *wp-backup*(1)

--- a/man/wp-speed-test.md
+++ b/man/wp-speed-test.md
@@ -3,33 +3,42 @@ title: "wp-speed-test"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-speed-test - manual page for wp-speed-test git version fba2a66
+wp-speed-test - manual page for wp-speed-test git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-speed-test \[--cache\] \[-h\] \[--version\] \[URL\]
+usage: wp-speed-test \[\--cache\] \[-h\] \[\--version\] \[URL\]
 
 wp-speed-test measures the load time of PHP responses.
 
-## positional arguments:
+positional arguments:
+---------------------
 
-  - URL  
-    The site URL to be tested. Defaults to using output of wp-url if the
+URL
+
+:   The site URL to be tested. Defaults to using output of wp-url if the
     argument is not given.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **--cache**  
-    Measures cached results. This does not measure actual PHP speed.
+**\--cache**
 
-  - **-h**, **--help**  
-    display this help and exit
+:   Measures cached results. This does not measure actual PHP speed.
 
-  - **--version**  
-    display version and exit
+**-h**, **\--help**
 
-# SEE ALSO
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit
+
+SEE ALSO
+========
 
 *wp-load-test*(1)

--- a/man/wp-ssh-production.md
+++ b/man/wp-ssh-production.md
@@ -3,21 +3,26 @@ title: "wp-ssh-production"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-ssh-production - manual page for wp-ssh-production git version
-fba2a66
+8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-ssh-production \[-h\] \[--version\]"
+usage: wp-ssh-production \[-h\] \[\--version\]\"
 
 SSH into production container.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    display this help and exit
+**-h**, **\--help**
 
-  - **--version**  
-    display version and exit
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit

--- a/man/wp-static-export.md
+++ b/man/wp-static-export.md
@@ -3,33 +3,41 @@ title: "wp-static-export"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-static-export - manual page for wp-static-export git version fba2a66
+wp-static-export - manual page for wp-static-export git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-static-export \[-h\] \[--version\] \[URL \[OUTPUT\_DIR\]\]
+usage: wp-static-export \[-h\] \[\--version\] \[URL \[OUTPUT\_DIR\]\]
 
 Export a static version of the site. All pages and assets of the
 WordPress site will be crawled and saved as static HTML files, which
 might be useful in certain static file use cases.
 
-Note\! This tool is experimental and currently useful only to developers
+Note! This tool is experimental and currently useful only to developers
 who will further process the static files generated at */data/static*.
 
-## positional arguments:
+positional arguments:
+---------------------
 
-  - URL  
-    Site URL to export. Defaults to the output of wp-url command.
+URL
 
-  - OUTPUT\_DIR  
-    Defaults to */data/static*.
+:   Site URL to export. Defaults to the output of wp-url command.
 
-## optional arguments:
+OUTPUT\_DIR
 
-  - **-h**, **--help**  
-    display this help and exit
+:   Defaults to */data/static*.
 
-  - **--version**  
-    display version and exit
+optional arguments:
+-------------------
+
+**-h**, **\--help**
+
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit

--- a/man/wp-test-whitelist.md
+++ b/man/wp-test-whitelist.md
@@ -3,63 +3,76 @@ title: "wp-test-whitelist"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-test-whitelist - manual page for wp-test-whitelist git version
-fba2a66
+8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
 usage: Command for whitelisting wp-test errors and warnings
 
-Whitelist Chrome developer console errors so that they don't get caught
+Whitelist Chrome developer console errors so that they don\'t get caught
 when running wp-test. Occasionally, the Chrome developer console outputs
 false positive errors that should just be ignored by wp-test.
 
 You can whitelist an error output by either typing in the whole error
 string or whitelist many similar errors by utilizing regular expression.
-You can also specify, if the message you're whitelisting, is an error or
-a warning.
+You can also specify, if the message you\'re whitelisting, is an error
+or a warning.
 
 Whitelist a single message
 
-> wp-test-whitelist **--add** "https://example.com/favicon.ico 404 (Not
-> Found)"
+> wp-test-whitelist **\--add** \"https://example.com/favicon.ico 404
+> (Not Found)\"
 
 Whitelist multiple errors with regex
 
-> wp-test-whitelist **--add** ".\*example\\.com/mylibrary\\.js.\*404.\*"
-> **--regex**
+> wp-test-whitelist **\--add**
+> \".\*example\\.com/mylibrary\\.js.\*404.\*\" **\--regex**
 
-## Read more about whitelisting:
+Read more about whitelisting:
+-----------------------------
 
 > https://seravo.com/docs/tests/ng-integration-tests/\#howto-whitelist-specific-harmless-chrome-console-errors
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    show this help message and exit
+**-h**, **\--help**
 
-  - **--version**  
-    show program's version number and exit
+:   show this help message and exit
 
-  - **--list**  
-    Show a list of whitelist entries
+**\--version**
 
-  - **--add** MESSAGE  
-    Whitelist given message
+:   show program\'s version number and exit
 
-  - **--delete**  
-    Unwhitelist given message
+**\--list**
 
-  - **--reset**  
-    Clear the whitelist
+:   Show a list of whitelist entries
 
-  - **--error**  
-    Specify messages's level to be error
+**\--add** MESSAGE
 
-  - **--warning**  
-    Specify messages's level to be warning
+:   Whitelist given message
 
-  - **--regex**  
-    Use regular expression
+**\--delete**
+
+:   Unwhitelist given message
+
+**\--reset**
+
+:   Clear the whitelist
+
+**\--error**
+
+:   Specify messages\'s level to be error
+
+**\--warning**
+
+:   Specify messages\'s level to be warning
+
+**\--regex**
+
+:   Use regular expression

--- a/man/wp-test.md
+++ b/man/wp-test.md
@@ -3,16 +3,19 @@ title: "wp-test"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-test - manual page for wp-test git version fba2a66
+wp-test - manual page for wp-test git version 8235fae
 
-# SYNOPSIS
+SYNOPSIS
+========
 
-**wp-test** \[*-h*\] \[*--version*\] \[*--insecure*\] \[*--debug*\]
-\[*--fail-fast*\]
+**wp-test** \[*-h*\] \[*\--version*\] \[*\--insecure*\] \[*\--debug*\]
+\[*\--fail-fast*\]
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
 Test that the WordPress installation works. Runs a set of standard
 Seravo tests and any custom tests the site might have. Note, that if the
@@ -22,21 +25,27 @@ For full documentation please read
 https://seravo.com/docs/tests/ng-integration-tests/
 
 Based on Codeception PHP testing framework. Any additional arguments are
-passed as-is to 'codecept'.
+passed as-is to \'codecept\'.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **--insecure**  
-    ignore HTTPS certificate issues
+**\--insecure**
 
-  - **--fail-fast**  
-    stop tests on first error that occurred
+:   ignore HTTPS certificate issues
 
-  - **--debug**  
-    display verbose debug information
+**\--fail-fast**
 
-  - **-h**, **--help**  
-    display this help and exit
+:   stop tests on first error that occurred
 
-  - **--version**  
-    display version and exit
+**\--debug**
+
+:   display verbose debug information
+
+**-h**, **\--help**
+
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit

--- a/man/wp-theme-security-check.md
+++ b/man/wp-theme-security-check.md
@@ -3,30 +3,37 @@ title: "wp-theme-security-check"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-theme-security-check - manual page for wp-theme-security-check git
-version fba2a66
+version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-theme-security-check \[--force\] \[-h\] \[--version\]
+usage: wp-theme-security-check \[\--force\] \[-h\] \[\--version\]
 
 Check WordPress theme security with phpcs and log each run. Makes the
 check if a prior check has not been made or if files have been changed
 since last check.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **--force**  
-    Force running security check
+**\--force**
 
-  - **-h**, **--help**  
-    display this help and exit
+:   Force running security check
 
-  - **--version**  
-    display version and exit
+**-h**, **\--help**
 
-# SEE ALSO
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit
+
+SEE ALSO
+========
 
 *phpcs*(1)

--- a/man/wp-url.md
+++ b/man/wp-url.md
@@ -3,22 +3,27 @@ title: "wp-url"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-url - manual page for wp-url git version fba2a66
+wp-url - manual page for wp-url git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-url \[-h\] \[--version\]
+usage: wp-url \[-h\] \[\--version\]
 
 Print the URL of the WordPress website. Show what is the full URL to the
 WordPress site main page. For details see
 https://seravo.com/docs/configuration/redirect/\#understanding-the-differenceof-get\_home-and-get\_siteurl-in-wordpress
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    show this help message and exit
+**-h**, **\--help**
 
-  - **--version**  
-    show program's version number and exit
+:   show this help message and exit
+
+**\--version**
+
+:   show program\'s version number and exit

--- a/man/wp-vagrant-activation.md
+++ b/man/wp-vagrant-activation.md
@@ -3,21 +3,26 @@ title: "wp-vagrant-activation"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-vagrant-activation - manual page for wp-vagrant-activation git
-version fba2a66
+version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-vagrant-activation \[-h\] \[--version\]"
+usage: wp-vagrant-activation \[-h\] \[\--version\]\"
 
 Runs commands needed during vagrant up.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    display this help and exit
+**-h**, **\--help**
 
-  - **--version**  
-    display version and exit
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit

--- a/man/wp-vagrant-dump-db.md
+++ b/man/wp-vagrant-dump-db.md
@@ -3,21 +3,26 @@ title: "wp-vagrant-dump-db"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-vagrant-dump-db - manual page for wp-vagrant-dump-db git version
-fba2a66
+8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-vagrant-dump-db \[-h\] \[--version\]
+usage: wp-vagrant-dump-db \[-h\] \[\--version\]
 
 Dump WordPress DB into .vagrant folder.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    display this help and exit
+**-h**, **\--help**
 
-  - **--version**  
-    display version and exit
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit

--- a/man/wp-vagrant-import-db.md
+++ b/man/wp-vagrant-import-db.md
@@ -3,21 +3,26 @@ title: "wp-vagrant-import-db"
 ---
 
 
-# NAME
+NAME
+====
 
 wp-vagrant-import-db - manual page for wp-vagrant-import-db git version
-fba2a66
+8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-vagrant-import-db \[-h\] \[--version\]
+usage: wp-vagrant-import-db \[-h\] \[\--version\]
 
 Import WordPress DB from .vagrant folder.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    display this help and exit
+**-h**, **\--help**
 
-  - **--version**  
-    display version and exit
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit

--- a/man/wp-watch-logs.md
+++ b/man/wp-watch-logs.md
@@ -3,20 +3,25 @@ title: "wp-watch-logs"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-watch-logs - manual page for wp-watch-logs git version fba2a66
+wp-watch-logs - manual page for wp-watch-logs git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-watch-logs \[-h\] \[--version\]
+usage: wp-watch-logs \[-h\] \[\--version\]
 
 Start watching all the logs under /data/log/.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    display this help and exit
+**-h**, **\--help**
 
-  - **--version**  
-    display version and exit
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit

--- a/man/wp-xdebug-off.md
+++ b/man/wp-xdebug-off.md
@@ -3,20 +3,25 @@ title: "wp-xdebug-off"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-xdebug-off - manual page for wp-xdebug-off git version fba2a66
+wp-xdebug-off - manual page for wp-xdebug-off git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-xdebug-off \[-h\] \[--version\]
+usage: wp-xdebug-off \[-h\] \[\--version\]
 
 Disable Xdebug in local development so that the site runs faster.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    display this help and exit
+**-h**, **\--help**
 
-  - **--version**  
-    display version and exit
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit

--- a/man/wp-xdebug-on.md
+++ b/man/wp-xdebug-on.md
@@ -3,23 +3,28 @@ title: "wp-xdebug-on"
 ---
 
 
-# NAME
+NAME
+====
 
-wp-xdebug-on - manual page for wp-xdebug-on git version fba2a66
+wp-xdebug-on - manual page for wp-xdebug-on git version 8235fae
 
-# DESCRIPTION
+DESCRIPTION
+===========
 
-usage: wp-xdebug-on \[-h\] \[--version\]
+usage: wp-xdebug-on \[-h\] \[\--version\]
 
 Enable Xdebug.
 
-Remember to disable Xdebug with 'wp-xdebug-off' when done
+Remember to disable Xdebug with \'wp-xdebug-off\' when done
 debugging/profiling, since it slows down the WordPress site quite a lot.
 
-## optional arguments:
+optional arguments:
+-------------------
 
-  - **-h**, **--help**  
-    display this help and exit
+**-h**, **\--help**
 
-  - **--version**  
-    display version and exit
+:   display this help and exit
+
+**\--version**
+
+:   display version and exit


### PR DESCRIPTION
To ensure correct formatting of commands and parameters in the man pages, switch to native markdown instead of gfm. Fixes issue where commads had fancy typography (en dash, smart quotes) (Closes: #55).

Wasn't able to test this serving Jekyll locally as the theme doesn't cover markdown pages locally. My fork has an example man page that uses this new formatting: https://sjaks.github.io/docs/man/wp-test-whitelist/ (compare to https://seravo.com/docs/man/wp-test-whitelist/)

Fixed:
* double dashes are not intepreted as *en dash* characters
* quotes do not have smart typography features