### PR TITLE
Update PageSpeed documentation

### DIFF
--- a/_posts/2015-10-11-nginx.md
+++ b/_posts/2015-10-11-nginx.md
@@ -221,9 +221,12 @@ pagespeed on;
 ```
 
 #### Add some PageSpeed filters
+
+We have created a list of filters that might be beneficial to you in our environment. Due to PageSpeed's benefits being really site specific, you should do own testing on what is really needed.
+
 ```
-# This does a lot so test which of these you really need
-pagespeed EnableFilters rewrite_css,sprite_images,combine_css,inline_css,flatten_css_imports,inline_javascript,combine_javascript,inline_google_font_css,canonicalize_javascript_libraries,rewrite_images,recompress_images;
+# Optimize resource loading
+pagespeed EnableFilters rewrite_css,combine_css,inline_css,flatten_css_imports,inline_javascript,combine_javascript,inline_google_font_css,canonicalize_javascript_libraries;
 ```
 
-Note that with the introduction of HTTP/2, many of the techniques used by PageSpeed have become obsolete. Currently very few of our customers use PageSpeed because of the limited benefits it brings.
+Note that with the introduction of HTTP/2, many of the techniques used by PageSpeed have become obsolete. Currently very few of our customers use PageSpeed because of the limited benefits it brings but also due to the alternative site optimization methods we provide. For example, the image optimization filters provided in PageSpeed can be replaced by [Seravo Plugin](/docs/configuration/wppalvelu-plugin/#optimize-images) and using [an alternative way to show WebP images](/docs/configuration/webp-images/).


### PR DESCRIPTION
Drop image optimization filters from recommendations and explain the alternatives. Show only the filters that really benefit users in Seravo's environment.

This has been discussed for a while now. I think PageSpeed is great in minimizing JS/CSS and optimizing how those resources are loaded. Removing "support" for it is not a good idea but it should be made clear that many of its features are not useful in our environment.

```
pagespeed EnableFilters rewrite_css,combine_css,inline_css,flatten_css_imports,inline_javascript,combine_javascript,inline_google_font_css,canonicalize_javascript_libraries;
```