### PR TITLE
Add trailing slashes to permalinks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -58,43 +58,43 @@ collections:
   get-started:
     title: "Get Started"
     output: true
-    permalink: /:collection/:name
+    permalink: /:collection/:name/
     sequence: 1
     searchable: true
   configuration:
     title: "Configuration"
     output: true
-    permalink: /:collection/:name
+    permalink: /:collection/:name/
     sequence: 2
     searchable: true
   tests:
     title: "Tests"
     output: true
-    permalink: /:collection/:name
+    permalink: /:collection/:name/
     sequence: 3
     searchable: true
   development:
     title: "Development"
     output: true
-    permalink: /:collection/:name
+    permalink: /:collection/:name/
     sequence: 4
     searchable: true
   deployment:
     title: "Deployment"
     output: true
-    permalink: /:collection/:name
+    permalink: /:collection/:name/
     sequence: 5
     searchable: true
   management:
     title: "Management"
     output: true
-    permalink: /:collection/:name
+    permalink: /:collection/:name/
     sequence: 6
     searchable: true
   man:
     title: "Man pages"
     output: true
-    permalink: /:collection/:name
+    permalink: /:collection/:name/
     searchable: true
 
 highlighter: rouge


### PR DESCRIPTION
To ensure urls with and without trailing slasles take to the correct
page, include a slash at the end of permalinks

Kudos to @Moppa5 for finding a possible solution quickly

```
bundle install --path vendor/bundle
bundle exec jekyll serve

curl -L http://127.0.0.1:4000/docs/get-started/available-commands
curl -L http://127.0.0.1:4000/docs/get-started/available-commands/
```